### PR TITLE
Rename `optional_update` to `latest_version`

### DIFF
--- a/ExampleApp/build.gradle
+++ b/ExampleApp/build.gradle
@@ -17,6 +17,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/ExampleApp/build.gradle
+++ b/ExampleApp/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         applicationId "co.infinum.povexampleapp"

--- a/ExampleApp/src/main/res/raw/update.json
+++ b/ExampleApp/src/main/res/raw/update.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ If you are using a default parser, version in your application and the JSON file
 {
 	"ios": {
 		"minimum_version": "1.2.3",
-		"optional_update": {
+		"latest_version": {
 			"version": "2.4.5",
 			"notification_type": "ALWAYS"
 		}
 	},
 	"android": {
 		"minimum_version": "1.2.3",
-		"optional_update": {
+		"latest_version": {
 			"version": "2.4.5",
 			"notification_type": "ONCE"
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/circle.yml
+++ b/circle.yml
@@ -25,3 +25,6 @@ test:
     # copy the build outputs to artifacts
     - cp -r prince-of-versions/build/outputs $CIRCLE_ARTIFACTS
     - cp -r prince-of-versions/build/reports $CIRCLE_ARTIFACTS
+    # set up test summary
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
 
 test:
   override:
-    # build the project and run static analysis while we wait for the emulator to boot (lint, pmd, findbugs, checkstyle)
+    # build the project and run static analysis, tests
    - ./gradlew assembleDebug check -PdisablePreDex
   post:
     # copy the build outputs to artifacts

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ machine:
 dependencies:
   pre:
       - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,android-24,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository"
-      - echo y | android update sdk --no-ui --all --filter "build-tools-24.0.0"
+      - echo y | android update sdk --no-ui --all --filter "build-tools-24.0.2"
 
 test:
   override:

--- a/prince-of-versions/build.gradle
+++ b/prince-of-versions/build.gradle
@@ -6,13 +6,13 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    buildToolsVersion '24.0.2'
 
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 24
         versionCode 1
-        versionName "1.0.1"
+        versionName "2.0.0"
     }
     buildTypes {
         release {

--- a/prince-of-versions/build.gradle
+++ b/prince-of-versions/build.gradle
@@ -20,18 +20,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    sourceSets { main { resources.srcDirs = ['src/main/res“ources', 'src/test/resources/'] } }
+    sourceSets { main { resources.srcDirs = ['src/main/resources', 'src/test/resources/'] } }
 
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.github.zafarkhaja:java-semver:0.9.0'
+    compile 'com.android.support:appcompat-v7:24.0.0'
+
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.1.1"
-    compile 'com.android.support:appcompat-v7:24.0.0'
-    testCompile 'org.mockito:mockito-core:1.+'
-
-    compile 'com.github.zafarkhaja:java-semver:0.9.0'
+    testCompile 'org.mockito:mockito-core:2.2.3'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
 }
 

--- a/prince-of-versions/src/main/java/co/infinum/princeofversions/helpers/parsers/JsonVersionConfigParser.java
+++ b/prince-of-versions/src/main/java/co/infinum/princeofversions/helpers/parsers/JsonVersionConfigParser.java
@@ -21,7 +21,7 @@ import co.infinum.princeofversions.exceptions.ParseException;
  * object. Android object can contain keys as follow:
  * <ul>
  * <li><i>minimum_version</i></li>
- * <li><i>optional_update</i></li>
+ * <li><i>latest_version</i></li>
  * </ul>.
  * Valid content can also have <i>meta</i> key. Value contained in <i>meta</i> key is JSON object containing metadata ordered in key-value
  * pairs.
@@ -50,7 +50,7 @@ import co.infinum.princeofversions.exceptions.ParseException;
  *  {
  *      "android": {
  *          "minimum_version": "1.2.3",
- *          "optional_update": {
+ *          "latest_version": {
  *              "version": "2.4.5",
  *              "notification_type": "ONCE"
  *          }
@@ -77,9 +77,9 @@ public class JsonVersionConfigParser implements VersionConfigParser {
     public static final String MINIMUM_VERSION = "minimum_version";
 
     /**
-     * Optional update key
+     * Latest version key
      */
-    public static final String OPTIONAL_UPDATE = "optional_update";
+    public static final String LATEST_VERSION = "latest_version";
 
     /**
      * Notification type key
@@ -144,8 +144,8 @@ public class JsonVersionConfigParser implements VersionConfigParser {
         );
 
         /*  optional */
-        if (android.has(OPTIONAL_UPDATE)) {
-            JSONObject updateObject = android.getJSONObject(OPTIONAL_UPDATE);
+        if (android.has(LATEST_VERSION)) {
+            JSONObject updateObject = android.getJSONObject(LATEST_VERSION);
             String update = updateObject.getString(VERSION);
             Version updateVersion = Version.valueOf(update);
 

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/MetadataTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/MetadataTest.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
@@ -31,9 +32,6 @@ import co.infinum.princeofversions.interfaces.VersionVerifierFactory;
 import co.infinum.princeofversions.loaders.ResourceFileLoader;
 import co.infinum.princeofversions.util.ResourceUtils;
 import co.infinum.princeofversions.verifiers.SingleThreadVersionVerifier;
-
-import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.eq;
 
 /**
  * Created by Juraj Pejnović on 08/09/16.
@@ -87,7 +85,7 @@ public class MetadataTest {
 
         Mockito.verify(callback, Mockito.times(1)).onNewUpdate("2.4.5", false, data);
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -127,7 +125,7 @@ public class MetadataTest {
 
         Mockito.verify(callback, Mockito.times(1)).onNewUpdate("2.4.5", false, data);
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -165,7 +163,7 @@ public class MetadataTest {
 
         Mockito.verify(callback, Mockito.times(1)).onNewUpdate("2.4.5", false, data);
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -201,7 +199,7 @@ public class MetadataTest {
 
         Mockito.verify(callback, Mockito.times(1)).onNewUpdate("2.4.5", false, data);
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -237,7 +235,7 @@ public class MetadataTest {
 
         Mockito.verify(callback, Mockito.times(1)).onNewUpdate("2.4.5", false, data);
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/NetworkLoaderTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/NetworkLoaderTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -15,7 +16,6 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.util.Log;
 
 import java.io.IOException;
 
@@ -129,8 +129,8 @@ public class NetworkLoaderTest {
         versionVerifier.verify(loader, listener);
 
         verify(callback, timeout(20000).times(1)).onError(ErrorCode.LOAD_ERROR);
-        verify(callback, never()).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
-        verify(callback, never()).onNoUpdate(Mockito.anyMap());
+        verify(callback, never()).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
+        verify(callback, never()).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
 

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/PrinceOfVersionsTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/PrinceOfVersionsTest.java
@@ -3,6 +3,7 @@ package co.infinum.princeofversions.tests;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
@@ -74,7 +75,7 @@ public class PrinceOfVersionsTest {
                 return new ResourceFileLoader("valid_update_no_notification.json");
             }
         }, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -90,7 +91,7 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -106,9 +107,10 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -138,7 +140,7 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -154,7 +156,7 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -170,7 +172,7 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.4.5"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -186,9 +188,10 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -202,9 +205,10 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -218,10 +222,11 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
-    Mockito.verifyNoMoreInteractions(callback);
+        Mockito.verifyNoMoreInteractions(callback);
     }
 
     @Test
@@ -235,7 +240,8 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -251,7 +257,8 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -267,7 +274,8 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -283,7 +291,8 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -299,9 +308,10 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.WRONG_VERSION);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -315,15 +325,17 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.WRONG_VERSION);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
     public void testCheckingWhenVersionIsAlreadyNotified() throws PackageManager.NameNotFoundException {
         Context context = setupContext("2.0.0");
         VersionRepository repo = Mockito.mock(VersionRepository.class);
+        Mockito.when(repo.getLastVersionName(null)).thenReturn("2.4.5");
         Mockito.when(repo.getLastVersionName(Mockito.anyString())).thenReturn("2.4.5");
         PrinceOfVersions updater = new PrinceOfVersions(context, provider, repo);
         updater.checkForUpdates(new LoaderFactory() {
@@ -333,9 +345,10 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.WRONG_VERSION);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -349,9 +362,10 @@ public class PrinceOfVersionsTest {
             }
         }, callback);
 
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0))
+                .onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
 }

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/VerifierTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/tests/VerifierTest.java
@@ -3,6 +3,7 @@ package co.infinum.princeofversions.tests;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -79,7 +80,7 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -102,9 +103,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -125,9 +126,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -148,9 +149,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -171,9 +172,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-beta2"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-beta2"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -194,9 +195,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -217,9 +218,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-rc1"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-rc1"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -240,9 +241,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-b45"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-b45"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -263,7 +264,7 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.1"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.1"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
         Mockito.verify(callback, Mockito.times(0)).onNoUpdate(null);
     }
@@ -287,9 +288,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.1"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.1"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -310,9 +311,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.1"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.1"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -333,9 +334,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.1"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.1"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -356,9 +357,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-beta3"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("2.0.0-beta3"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -379,9 +380,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.1"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.1"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -402,9 +403,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0-rc1"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0-rc1"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -425,9 +426,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0-b45"), eq(false), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("3.0.0-b45"), eq(false), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -448,9 +449,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -466,9 +467,9 @@ public class VerifierTest {
         }).when(versionVerifier).verify(Mockito.any(UpdateConfigLoader.class), Mockito.any(VersionVerifierListener.class));
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNewUpdate(Mockito.anyString(), Mockito.anyBoolean(), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(1)).onError(ErrorCode.WRONG_VERSION);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
 
@@ -490,9 +491,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("1.1.1"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("1.1.1"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -513,9 +514,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("1.1.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("1.1.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
     @Test
@@ -536,9 +537,9 @@ public class VerifierTest {
 
         PrinceOfVersions updater = new PrinceOfVersions(new MockContext(), provider, repository);
         updater.checkForUpdates(loaderFactory, callback);
-        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("1.1.0"), eq(true), Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(1)).onNewUpdate(eq("1.1.0"), eq(true), ArgumentMatchers.<String, String>anyMap());
         Mockito.verify(callback, Mockito.times(0)).onError(ErrorCode.UNKNOWN_ERROR);
-        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(Mockito.anyMap());
+        Mockito.verify(callback, Mockito.times(0)).onNoUpdate(ArgumentMatchers.<String, String>anyMap());
     }
 
 }

--- a/prince-of-versions/src/test/resources/mockdata/invalid_update_invalid_version.json
+++ b/prince-of-versions/src/test/resources/mockdata/invalid_update_invalid_version.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/invalid_update_no_android.json
+++ b/prince-of-versions/src/test/resources/mockdata/invalid_update_no_android.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "no_android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/invalid_update_no_min_version.json
+++ b/prince-of-versions/src/test/resources/mockdata/invalid_update_no_min_version.json
@@ -1,13 +1,13 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/invalid_update_optional_without_version.json
+++ b/prince-of-versions/src/test/resources/mockdata/invalid_update_optional_without_version.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "notification_type": "ONCE"
     }
   }

--- a/prince-of-versions/src/test/resources/mockdata/malformed_json.json
+++ b/prince-of-versions/src/test/resources/mockdata/malformed_json.json
@@ -1,14 +1,14 @@
 {
   not_ios: {
     not_minimum_version: "1.2.3",
-    not_optional_update: {
+    not_latest_version: {
       not_version: "2.4.5",
       not_notification_type: "ALWAYS"
     }
   },
   not_android: {
     not_minimum_version: "1.2.3",
-    not_optional_update": {
+    not_latest_version": {
       not_version: "2.4.5",
       not_notification_type: "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_b.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_b.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3-b12",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5-b45",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_beta.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_beta.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3-beta2",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5-beta3",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_rc.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_rc.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3-rc2",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5-rc3",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata_empty.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata_empty.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata_malformed.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata_malformed.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata_null.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_full_with_metadata_null.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_no_notification.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_no_notification.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5"
     }
   }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_notification_always.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_notification_always.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_only_min_version.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_only_min_version.json
@@ -1,7 +1,7 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_with_metadata
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_with_metadata
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_with_metadata_empty.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_with_metadata_empty.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }

--- a/prince-of-versions/src/test/resources/mockdata/valid_update_without_codes.json
+++ b/prince-of-versions/src/test/resources/mockdata/valid_update_without_codes.json
@@ -1,14 +1,14 @@
 {
   "ios": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ALWAYS"
     }
   },
   "android": {
     "minimum_version": "1.2.3",
-    "optional_update": {
+    "latest_version": {
       "version": "2.4.5",
       "notification_type": "ONCE"
     }


### PR DESCRIPTION
Talking to one of our web devs I realized that the naming in the json file is a bit confusing so this PR fixes that. If you are the one maintaining the json file, it's much more natural to call this property `latest_version` that `optional_update`.

This PR also bumps mockito to the latest version since the tests were broken for me because of the variable mockito dependency. All the Mockito related changes are due to changes in the Mockito API with 2.0.

Since this change breaks the `API` of the library, this PR also increments the major version to respect semver.