### PR TITLE
Removed application tag from Android Manifest.

### DIFF
--- a/prince-of-versions/src/main/AndroidManifest.xml
+++ b/prince-of-versions/src/main/AndroidManifest.xml
@@ -3,9 +3,4 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application
-            android:label="@string/app_name"
-            android:supportsRtl="true">
-    </application>
-
 </manifest>


### PR DESCRIPTION
This tag is unnecessary and causes the end library user to use Manifest Markers to resolve Manifest Merger issues (label and supportsRtl)