### PR TITLE
Fix condition for unspecified requirement checker

### DIFF
--- a/prince-of-versions/CHANGELOG.md
+++ b/prince-of-versions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 4.0.1
+
+_2020-06-05_
+
+- fix resolution of missing custom requirements checker
+    Any requirement specified in the configuration is from now on required to be satisfied to be able to use that update.
+    If application doesn't support that requirement, update won't be considered valid for that device and it will be skipped.
+
 ## Version 4.0.0
 
 _2020-03-29_

--- a/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersionsDefaultRequirementsChecker.java
+++ b/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersionsDefaultRequirementsChecker.java
@@ -16,7 +16,6 @@ class PrinceOfVersionsDefaultRequirementsChecker implements RequirementChecker {
      * @param value Json data that contains all requirements for new update
      * @return true or false depending if are required requirements matched
      */
-
     @Override
     public boolean checkRequirements(String value) {
         int minSdk = Integer.parseInt(value);

--- a/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersionsRequirementsProcessor.java
+++ b/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersionsRequirementsProcessor.java
@@ -20,7 +20,7 @@ class PrinceOfVersionsRequirementsProcessor {
         try {
             for (Map.Entry<String, String> requirement : requirements.entrySet()) {
                 RequirementChecker checker = installedCheckers.get(requirement.getKey());
-                if (checker == null || checker.checkRequirements(requirement.getValue())) {
+                if (checker != null && checker.checkRequirements(requirement.getValue())) {
                     continue;
                 }
                 return false;

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/JsonConfigurationParserTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/JsonConfigurationParserTest.java
@@ -1,36 +1,29 @@
 package co.infinum.princeofversions;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-
 import co.infinum.princeofversions.mocks.MockApplicationConfiguration;
 import co.infinum.princeofversions.mocks.MockDefaultRequirementChecker;
 import co.infinum.princeofversions.util.MapUtil;
 import co.infinum.princeofversions.util.ResourceUtils;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
 
 import static co.infinum.princeofversions.util.MapUtil.entry;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class JsonConfigurationParserTest {
 
-    private static final String DEFAULT_OS_VERSION = "required_os_version";
-
     private JsonConfigurationParser parser;
 
     @Before
     public void setUp() {
-        parser = new JsonConfigurationParser(new PrinceOfVersionsRequirementsProcessor());
-    }
-
-    @After
-    public void tearDown() {
-        parser = null;
+        Map<String, RequirementChecker> defaultRequirements = new HashMap<>();
+        defaultRequirements.put(PrinceOfVersionsDefaultRequirementsChecker.KEY, new MockDefaultRequirementChecker(21));
+        parser = new JsonConfigurationParser(new PrinceOfVersionsRequirementsProcessor(defaultRequirements));
     }
 
     @Test
@@ -41,28 +34,28 @@ public class JsonConfigurationParserTest {
     @Test
     public void checkJsonToStringMap() throws Throwable {
         assertThat(
-            parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string.json")))
+                parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string.json")))
         ).isEqualTo(
-            MapUtil.from(
-                entry("key1", "value1"),
-                entry("key2", "value2")
-            )
+                MapUtil.from(
+                        entry("key1", "value1"),
+                        entry("key2", "value2")
+                )
         );
     }
 
     @Test
     public void checkComplexJsonToStringMap() throws Throwable {
         assertThat(
-            parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string_complex.json")))
+                parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string_complex.json")))
         ).isEqualTo(
-            MapUtil.from(
-                entry("key1", "value1"),
-                entry("key2", "value2"),
-                entry("key3", "true"),
-                entry("key4", "0"),
-                entry("key5", "[0,1]"),
-                entry("key6", "{}")
-            )
+                MapUtil.from(
+                        entry("key1", "value1"),
+                        entry("key2", "value2"),
+                        entry("key3", "true"),
+                        entry("key4", "0"),
+                        entry("key5", "[0,1]"),
+                        entry("key6", "{}")
+                )
         );
     }
 
@@ -85,13 +78,13 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .build()
         );
     }
 
@@ -99,17 +92,17 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithMetadataJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .withMetadata(MapUtil.from(
-                    entry("key1", "value1"),
-                    entry("key2", "value2")
-                ))
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .withMetadata(MapUtil.from(
+                                entry("key1", "value1"),
+                                entry("key2", "value2")
+                        ))
+                        .build()
         );
     }
 
@@ -117,14 +110,14 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithEmptyMetadataJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_empty.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .withMetadata(new HashMap<String, String>())
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .withMetadata(new HashMap<String, String>())
+                        .build()
         );
     }
 
@@ -137,14 +130,14 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithNullMetadataJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_null.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .withMetadata(new HashMap<String, String>())
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .withMetadata(new HashMap<String, String>())
+                        .build()
         );
     }
 
@@ -152,16 +145,16 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithSdkValuesJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_sdk_values.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(240)
-                .withRequirements(MapUtil.from(
-                    entry("required_os_version", "17")
-                ))
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(240)
+                        .withRequirements(MapUtil.from(
+                                entry("required_os_version", "17")
+                        ))
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .build()
         );
     }
 
@@ -169,12 +162,12 @@ public class JsonConfigurationParserTest {
     public void noMandatoryVersionJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_no_min_version.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .build()
         );
     }
 
@@ -182,13 +175,13 @@ public class JsonConfigurationParserTest {
     public void validUpdateNoNotificationJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_no_notification.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ONCE)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ONCE)
+                        .build()
         );
     }
 
@@ -196,13 +189,13 @@ public class JsonConfigurationParserTest {
     public void validUpdateAlwaysNotificationJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_notification_always.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withOptionalNotificationType(NotificationType.ALWAYS)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withOptionalNotificationType(NotificationType.ALWAYS)
+                        .build()
         );
     }
 
@@ -215,11 +208,11 @@ public class JsonConfigurationParserTest {
     public void validUpdateOnlyMandatoryJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_only_min_version.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .build()
         );
     }
 
@@ -227,12 +220,12 @@ public class JsonConfigurationParserTest {
     public void validUpdateWithJsonArray() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .build()
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .build()
         );
     }
 
@@ -240,31 +233,31 @@ public class JsonConfigurationParserTest {
     public void validUpdateWithMergingMetadata() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_metadata.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withMetadata(MapUtil.from(
-                    entry("x", "10"),
-                    entry("z", "3")
-                ))
-                .build());
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withMetadata(MapUtil.from(
+                                entry("x", "10"),
+                                entry("z", "3")
+                        ))
+                        .build());
     }
 
     @Test
     public void validUpdateWithOverridingMetadata() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_overriding_metadata.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(245)
-                .withMetadata(MapUtil.from(
-                    entry("x", "10")
-                ))
-                .build());
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(245)
+                        .withMetadata(MapUtil.from(
+                                entry("x", "10")
+                        ))
+                        .build());
     }
 
     @Test(expected = Throwable.class)
@@ -281,24 +274,24 @@ public class JsonConfigurationParserTest {
     public void validUpdateWithRequirements() throws Throwable {
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200, 13);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
-        PrinceOfVersionsRequirementsProcessor processor =
-            new PrinceOfVersionsRequirementsProcessor(Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
-        JsonConfigurationParser parser =
-            new JsonConfigurationParser(processor);
+        PrinceOfVersionsRequirementsProcessor processor = new PrinceOfVersionsRequirementsProcessor(
+                Collections.<String, RequirementChecker>singletonMap(PrinceOfVersionsDefaultRequirementsChecker.KEY, checker)
+        );
+        JsonConfigurationParser parser = new JsonConfigurationParser(processor);
 
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_requirements.json"));
         assertThat(
-            config
+                config
         ).isEqualTo(
-            new PrinceOfVersionsConfig.Builder()
-                .withMandatoryVersion(123)
-                .withOptionalVersion(246)
-                .build());
+                new PrinceOfVersionsConfig.Builder()
+                        .withMandatoryVersion(123)
+                        .withOptionalVersion(246)
+                        .build());
     }
 
     @Test(expected = Throwable.class)
     public void invalidDataInDefaultRequirementChecker() throws JSONException {
-        MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200,13);
+        MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200, 13);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
         checker.checkRequirements("not integer");
     }

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsTest.java
@@ -1,32 +1,26 @@
 package co.infinum.princeofversions;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Collections;
-import java.util.Map;
-
 import co.infinum.princeofversions.mocks.MockApplicationConfiguration;
 import co.infinum.princeofversions.mocks.MockDefaultRequirementChecker;
 import co.infinum.princeofversions.mocks.MockStorage;
 import co.infinum.princeofversions.mocks.ResourceFileLoader;
 import co.infinum.princeofversions.mocks.SingleThreadExecutor;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import static co.infinum.princeofversions.PrinceOfVersionsDefaultRequirementsChecker.KEY;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PrinceOfVersionsTest {
 
-    private static final String DEFAULT_OS_VERSION = "required_os_version";
+    private static final String DEFAULT_OS_VERSION = KEY;
 
     @Mock
     UpdaterCallback callback;
@@ -35,19 +29,15 @@ public class PrinceOfVersionsTest {
         return any(Throwable.class);
     }
 
-    private static Map<String, String> anyMap() {
-        return ArgumentMatchers.anyMap();
-    }
-
     @Test
     public void testCheckingValidContentNoNotification() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_no_notification.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_no_notification.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -59,7 +49,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNoNotificationSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_no_notification.json"));
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
         assertThat(result.getUpdateVersion()).isEqualTo(245);
@@ -70,11 +60,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlways() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_notification_always.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_notification_always.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -86,7 +76,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlwaysSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_notification_always.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -98,11 +88,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlwaysAlreadyNotified() {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_notification_always.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_notification_always.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -114,7 +104,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlwaysAlreadyNotifiedSync() throws Throwable {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_notification_always.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -126,11 +116,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentOnlyMinVersion() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_only_min_version.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_only_min_version.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -141,7 +131,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentOnlyMinVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_only_min_version.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -152,11 +142,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithoutCodes() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -168,7 +158,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithoutCodesSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -180,11 +170,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndLessThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -196,7 +186,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndLessThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -208,11 +198,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsLessThanMinAndLessThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(100,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -224,7 +214,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsLessThanMinAndLessThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(100,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -236,11 +226,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -252,7 +242,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -264,11 +254,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptionalButAlreadyNotified() {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -280,7 +270,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptionalButAlreadyNotifiedSync() throws Throwable {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -292,11 +282,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndEqualToOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -307,7 +297,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndEqualToOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -318,11 +308,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndGreaterThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -333,7 +323,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndGreaterThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -344,7 +334,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentWithInvalidVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("invalid_update_invalid_version.json"));
     }
 
@@ -352,11 +342,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoAndroidKey() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(
-            300, 16));
+                300, 16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("invalid_update_no_android.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("invalid_update_no_android.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -367,7 +357,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoAndroidKeySync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("invalid_update_no_android.json"));
     }
 
@@ -375,11 +365,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoJSON() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("invalid_update_no_android.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("invalid_update_no_android.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -390,7 +380,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoJSONSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("invalid_update_no_android.json"));
     }
 
@@ -398,11 +388,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithAlwaysNotification() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_notification_always.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_notification_always.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -413,7 +403,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithAlwaysNotificationSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_notification_always.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -424,11 +414,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithOnlyMinVersion() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_only_min_version.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_only_min_version.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -439,7 +429,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithOnlyMinVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_only_min_version.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -450,11 +440,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenVersionIsAlreadyNotified() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -465,7 +455,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenVersionIsAlreadyNotifiedSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -476,11 +466,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenUpdateShouldBeMade() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_no_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_no_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -492,7 +482,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenUpdateShouldBeMadeSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            16));
+                16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_no_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -507,11 +497,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(),
-            appConfig, Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                appConfig, Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -525,7 +515,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -540,11 +530,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -559,7 +549,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_single_sdk_value.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -574,11 +564,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -592,7 +582,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_huge_sdk_values.json"));
     }
 
@@ -603,11 +593,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -622,7 +612,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -637,11 +627,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -656,7 +646,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -671,11 +661,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -689,7 +679,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_huge_sdk_values.json"));
     }
 
@@ -697,14 +687,14 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValue() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -716,11 +706,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValueSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_single_sdk_value.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -732,15 +722,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValueAndHigherInitialVersion() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -752,11 +742,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValueAndHigherInitialVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_single_sdk_value.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -768,15 +758,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithSdkValues() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(140,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_mandatory_update.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_mandatory_update.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -788,11 +778,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithSdkValuesSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(140,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_mandatory_update.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -804,15 +794,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndTheSameVersions() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(245,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -823,11 +813,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndTheSameVersionsSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(245,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -838,15 +828,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndWithDifferentVersions() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(244,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -858,11 +848,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndWithDifferentVersionsSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(244,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -874,15 +864,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndIncreaseInMinor() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_full_with_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_full_with_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -893,11 +883,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndIncreaseInMinorSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full_with_sdk_values.json"));
     }
 
@@ -905,15 +895,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithHighSdkValuesAndIncreaseInMinor() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_big_increase_in_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_big_increase_in_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -924,11 +914,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithHighSdkValuesAndIncreaseInMinorSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-            16);
+                16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_big_increase_in_sdk_values.json"));
     }
 
@@ -936,15 +926,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithDeviceThatHasVeryLowMinSdk() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(100,
-            12);
+                12);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_same_sdk_values.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_same_sdk_values.json"),
+                callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -955,11 +945,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithDeviceThatHasVeryLowMinSdkSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(100,
-            12);
+                12);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_same_sdk_values.json"));
     }
 
@@ -967,15 +957,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithBigMinimumVersionMinSdk() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200,
-            23);
+                23);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -986,10 +976,18 @@ public class PrinceOfVersionsTest {
     @Test
     public void testCheckingOptionalUpdateWithBigMinimumVersionMinSdkSync() throws Throwable {
         Storage storage = new MockStorage();
-        PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-            23));
+        MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200, 23);
+        PrinceOfVersions princeOfVersions = new PrinceOfVersions(
+                storage,
+                new SingleThreadExecutor(),
+                applicationConfiguration,
+                Collections.<String, RequirementChecker>singletonMap(
+                        DEFAULT_OS_VERSION,
+                        new MockDefaultRequirementChecker(applicationConfiguration)
+                )
+        );
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk"
-            + ".json"));
+                + ".json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
         assertThat(result.getUpdateVersion()).isEqualTo(211);
@@ -1000,15 +998,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDate() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-            20);
+                20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -1019,13 +1017,13 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDateSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-            20);
+                20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk"
-            + ".json"));
+                + ".json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
         assertThat(result.getUpdateVersion()).isEqualTo(211);
@@ -1035,15 +1033,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDateAndNoMandatoryUpdateIsNotDefined() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-            20);
+                20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-            new SingleThreadExecutor(),
-            new ResourceFileLoader("valid_update_no_min_version.json"),
-            callback
+                new SingleThreadExecutor(),
+                new ResourceFileLoader("valid_update_no_min_version.json"),
+                callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -1054,11 +1052,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDateAndNoMandatoryUpdateIsNotDefinedSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-            20);
+                20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_no_min_version.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/mocks/MockDefaultRequirementChecker.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/mocks/MockDefaultRequirementChecker.java
@@ -1,10 +1,5 @@
 package co.infinum.princeofversions.mocks;
 
-import android.os.Build;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import co.infinum.princeofversions.ApplicationConfiguration;
 import co.infinum.princeofversions.RequirementChecker;
 
@@ -22,8 +17,12 @@ public class MockDefaultRequirementChecker implements RequirementChecker {
         this.sdkVersionCode = appConfig.sdkVersionCode();
     }
 
+    public MockDefaultRequirementChecker(int versionCode) {
+        this.sdkVersionCode = versionCode;
+    }
+
     @Override
-    public boolean checkRequirements(String value) throws JSONException {
+    public boolean checkRequirements(String value) {
         int minSdk = Integer.parseInt(value);
         return minSdk <= this.sdkVersionCode;
     }

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@ def build = [
 ]
 
 def versions = [
-        prince   : '4.0.0',
+        prince   : '4.0.1',
         queen    : '0.1.1',
         semver   : '0.9.0',
         appcompat: '1.1.0',


### PR DESCRIPTION
Any requirement specified in the configuration is from now on required to be satisfied to be able to use that update.
If application doesn't support that requirement, update won't be considered valid for that device and it will be skipped.