### PR TITLE
Integrate default requirement checkers when using constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Library checks update availability using In-App updates.
 #### Getting via jcenter
 
 ```groovy
-implementation 'co.infinum:queen-of-versions:0.2.0'
+implementation 'co.infinum:queen-of-versions:0.3.0'
 ```
 
 #### Features

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Library checks for updates using configuration from remote or local resource.
 #### Getting via jcenter
 
 ```groovy
-implementation 'co.infinum:prince-of-versions:4.0.1'
+implementation 'co.infinum:prince-of-versions:4.0.2'
 ```
 
 #### Features

--- a/prince-of-versions/CHANGELOG.md
+++ b/prince-of-versions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 4.0.2
+
+_2020-08-28_
+
+- integrate default requirements checker when using constructor
+    Default requirements checkers that PrinceOfVersions supports are from now on integrated even when using constructor
+    to create instance of the PrinceOfVersions class.
+
 ## Version 4.0.1
 
 _2020-06-05_

--- a/prince-of-versions/README.md
+++ b/prince-of-versions/README.md
@@ -8,7 +8,7 @@ Library checks for updates using configuration from remote or local resource.
 ## Getting via jcenter
 
 ```groovy
-implementation 'co.infinum:prince-of-versions:4.0.1'
+implementation 'co.infinum:prince-of-versions:4.0.2'
 ```
 
 ## Features

--- a/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersions.java
+++ b/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersions.java
@@ -1,13 +1,14 @@
 package co.infinum.princeofversions;
 
 import android.content.Context;
-import androidx.annotation.VisibleForTesting;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
+
+import androidx.annotation.VisibleForTesting;
 
 /**
  * This class represents main entry point for using library.
@@ -80,7 +81,8 @@ public final class PrinceOfVersions {
     }
 
     private static ConfigurationParser createDefaultParser() {
-        return new JsonConfigurationParser(new PrinceOfVersionsRequirementsProcessor());
+        Map<String, RequirementChecker> checkers = new HashMap<>();
+        return createDefaultParser(checkers);
     }
 
     private static ConfigurationParser createMockedParser(Map<String, RequirementChecker> requirementCheckers) {

--- a/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersionsDefaultRequirementsChecker.java
+++ b/prince-of-versions/src/main/java/co/infinum/princeofversions/PrinceOfVersionsDefaultRequirementsChecker.java
@@ -2,12 +2,29 @@ package co.infinum.princeofversions;
 
 import android.os.Build;
 
+import androidx.annotation.VisibleForTesting;
+
 /**
  * Represent a concrete implementation of {@link RequirementChecker} that will be used by a default.
  */
 class PrinceOfVersionsDefaultRequirementsChecker implements RequirementChecker {
 
     static final String KEY = "required_os_version";
+    private final ApplicationVersionProvider provider;
+
+    @VisibleForTesting
+    PrinceOfVersionsDefaultRequirementsChecker(ApplicationVersionProvider provider) {
+        this.provider = provider;
+    }
+
+    PrinceOfVersionsDefaultRequirementsChecker() {
+        this(new ApplicationVersionProvider() {
+            @Override
+            public int provide() {
+                return Build.VERSION.SDK_INT;
+            }
+        });
+    }
 
     /**
      * Basic implementation of this method that is going to be used by default.
@@ -19,6 +36,11 @@ class PrinceOfVersionsDefaultRequirementsChecker implements RequirementChecker {
     @Override
     public boolean checkRequirements(String value) {
         int minSdk = Integer.parseInt(value);
-        return minSdk <= Build.VERSION.SDK_INT;
+        return minSdk <= provider.provide();
+    }
+
+    interface ApplicationVersionProvider {
+
+        int provide();
     }
 }

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/JsonConfigurationParserTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/JsonConfigurationParserTest.java
@@ -1,16 +1,18 @@
 package co.infinum.princeofversions;
 
-import co.infinum.princeofversions.mocks.MockApplicationConfiguration;
-import co.infinum.princeofversions.mocks.MockDefaultRequirementChecker;
-import co.infinum.princeofversions.util.MapUtil;
-import co.infinum.princeofversions.util.ResourceUtils;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import co.infinum.princeofversions.mocks.MockApplicationConfiguration;
+import co.infinum.princeofversions.mocks.MockDefaultRequirementChecker;
+import co.infinum.princeofversions.util.MapUtil;
+import co.infinum.princeofversions.util.ResourceUtils;
 
 import static co.infinum.princeofversions.util.MapUtil.entry;
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -34,28 +36,28 @@ public class JsonConfigurationParserTest {
     @Test
     public void checkJsonToStringMap() throws Throwable {
         assertThat(
-                parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string.json")))
+            parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string.json")))
         ).isEqualTo(
-                MapUtil.from(
-                        entry("key1", "value1"),
-                        entry("key2", "value2")
-                )
+            MapUtil.from(
+                entry("key1", "value1"),
+                entry("key2", "value2")
+            )
         );
     }
 
     @Test
     public void checkComplexJsonToStringMap() throws Throwable {
         assertThat(
-                parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string_complex.json")))
+            parser.jsonObjectToMap(new JSONObject(ResourceUtils.readFromFile("json_obj_string_complex.json")))
         ).isEqualTo(
-                MapUtil.from(
-                        entry("key1", "value1"),
-                        entry("key2", "value2"),
-                        entry("key3", "true"),
-                        entry("key4", "0"),
-                        entry("key5", "[0,1]"),
-                        entry("key6", "{}")
-                )
+            MapUtil.from(
+                entry("key1", "value1"),
+                entry("key2", "value2"),
+                entry("key3", "true"),
+                entry("key4", "0"),
+                entry("key5", "[0,1]"),
+                entry("key6", "{}")
+            )
         );
     }
 
@@ -78,13 +80,13 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .build()
         );
     }
 
@@ -92,17 +94,17 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithMetadataJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .withMetadata(MapUtil.from(
-                                entry("key1", "value1"),
-                                entry("key2", "value2")
-                        ))
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .withMetadata(MapUtil.from(
+                    entry("key1", "value1"),
+                    entry("key2", "value2")
+                ))
+                .build()
         );
     }
 
@@ -110,14 +112,14 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithEmptyMetadataJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_empty.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .withMetadata(new HashMap<String, String>())
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .withMetadata(new HashMap<String, String>())
+                .build()
         );
     }
 
@@ -130,14 +132,14 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithNullMetadataJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_null.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .withMetadata(new HashMap<String, String>())
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .withMetadata(new HashMap<String, String>())
+                .build()
         );
     }
 
@@ -145,16 +147,16 @@ public class JsonConfigurationParserTest {
     public void validUpdateFullWithSdkValuesJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_sdk_values.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(240)
-                        .withRequirements(MapUtil.from(
-                                entry("required_os_version", "17")
-                        ))
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(240)
+                .withRequirements(MapUtil.from(
+                    entry("required_os_version", "17")
+                ))
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .build()
         );
     }
 
@@ -162,12 +164,12 @@ public class JsonConfigurationParserTest {
     public void noMandatoryVersionJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_no_min_version.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .build()
         );
     }
 
@@ -175,13 +177,13 @@ public class JsonConfigurationParserTest {
     public void validUpdateNoNotificationJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_no_notification.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ONCE)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ONCE)
+                .build()
         );
     }
 
@@ -189,13 +191,13 @@ public class JsonConfigurationParserTest {
     public void validUpdateAlwaysNotificationJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_notification_always.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withOptionalNotificationType(NotificationType.ALWAYS)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withOptionalNotificationType(NotificationType.ALWAYS)
+                .build()
         );
     }
 
@@ -208,11 +210,11 @@ public class JsonConfigurationParserTest {
     public void validUpdateOnlyMandatoryJson() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_only_min_version.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .build()
         );
     }
 
@@ -220,12 +222,12 @@ public class JsonConfigurationParserTest {
     public void validUpdateWithJsonArray() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .build()
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .build()
         );
     }
 
@@ -233,31 +235,31 @@ public class JsonConfigurationParserTest {
     public void validUpdateWithMergingMetadata() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_metadata.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withMetadata(MapUtil.from(
-                                entry("x", "10"),
-                                entry("z", "3")
-                        ))
-                        .build());
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withMetadata(MapUtil.from(
+                    entry("x", "10"),
+                    entry("z", "3")
+                ))
+                .build());
     }
 
     @Test
     public void validUpdateWithOverridingMetadata() throws Throwable {
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_overriding_metadata.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(245)
-                        .withMetadata(MapUtil.from(
-                                entry("x", "10")
-                        ))
-                        .build());
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(245)
+                .withMetadata(MapUtil.from(
+                    entry("x", "10")
+                ))
+                .build());
     }
 
     @Test(expected = Throwable.class)
@@ -275,18 +277,18 @@ public class JsonConfigurationParserTest {
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200, 13);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
         PrinceOfVersionsRequirementsProcessor processor = new PrinceOfVersionsRequirementsProcessor(
-                Collections.<String, RequirementChecker>singletonMap(PrinceOfVersionsDefaultRequirementsChecker.KEY, checker)
+            Collections.<String, RequirementChecker>singletonMap(PrinceOfVersionsDefaultRequirementsChecker.KEY, checker)
         );
         JsonConfigurationParser parser = new JsonConfigurationParser(processor);
 
         PrinceOfVersionsConfig config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_requirements.json"));
         assertThat(
-                config
+            config
         ).isEqualTo(
-                new PrinceOfVersionsConfig.Builder()
-                        .withMandatoryVersion(123)
-                        .withOptionalVersion(246)
-                        .build());
+            new PrinceOfVersionsConfig.Builder()
+                .withMandatoryVersion(123)
+                .withOptionalVersion(246)
+                .build());
     }
 
     @Test(expected = Throwable.class)

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/MockApplicationVersionProvider.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/MockApplicationVersionProvider.java
@@ -1,0 +1,15 @@
+package co.infinum.princeofversions;
+
+class MockApplicationVersionProvider implements PrinceOfVersionsDefaultRequirementsChecker.ApplicationVersionProvider {
+
+    private final int version;
+
+    MockApplicationVersionProvider(final int version) {
+        this.version = version;
+    }
+
+    @Override
+    public int provide() {
+        return version;
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsTest.java
@@ -1,15 +1,17 @@
 package co.infinum.princeofversions;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
 import co.infinum.princeofversions.mocks.MockApplicationConfiguration;
 import co.infinum.princeofversions.mocks.MockDefaultRequirementChecker;
 import co.infinum.princeofversions.mocks.MockStorage;
 import co.infinum.princeofversions.mocks.ResourceFileLoader;
 import co.infinum.princeofversions.mocks.SingleThreadExecutor;
-import java.util.Collections;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import static co.infinum.princeofversions.PrinceOfVersionsDefaultRequirementsChecker.KEY;
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -33,11 +35,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNoNotification() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_no_notification.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_no_notification.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -49,7 +51,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNoNotificationSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_no_notification.json"));
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
         assertThat(result.getUpdateVersion()).isEqualTo(245);
@@ -60,11 +62,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlways() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_notification_always.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_notification_always.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -76,7 +78,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlwaysSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_notification_always.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -88,11 +90,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlwaysAlreadyNotified() {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_notification_always.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_notification_always.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -104,7 +106,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentNotificationAlwaysAlreadyNotifiedSync() throws Throwable {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_notification_always.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -116,11 +118,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentOnlyMinVersion() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_only_min_version.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_only_min_version.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -131,7 +133,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentOnlyMinVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_only_min_version.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -142,11 +144,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithoutCodes() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -158,7 +160,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithoutCodesSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -170,11 +172,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndLessThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -186,7 +188,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndLessThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -198,11 +200,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsLessThanMinAndLessThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(100,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -214,7 +216,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsLessThanMinAndLessThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(100,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -226,11 +228,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -242,7 +244,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -254,11 +256,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptionalButAlreadyNotified() {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -270,7 +272,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsEqualToMinAndLessThanOptionalButAlreadyNotifiedSync() throws Throwable {
         Storage storage = new MockStorage(245);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(123,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -282,11 +284,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndEqualToOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -297,7 +299,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndEqualToOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -308,11 +310,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndGreaterThanOptional() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -323,7 +325,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingContentJSONWhenCurrentIsGreaterThanMinAndGreaterThanOptionalSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -334,7 +336,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentWithInvalidVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("invalid_update_invalid_version.json"));
     }
 
@@ -342,11 +344,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoAndroidKey() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(
-                300, 16));
+            300, 16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("invalid_update_no_android.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("invalid_update_no_android.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -357,7 +359,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoAndroidKeySync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("invalid_update_no_android.json"));
     }
 
@@ -365,11 +367,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoJSON() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("invalid_update_no_android.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("invalid_update_no_android.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -380,7 +382,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingInvalidContentNoJSONSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("invalid_update_no_android.json"));
     }
 
@@ -388,11 +390,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithAlwaysNotification() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_notification_always.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_notification_always.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -403,7 +405,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithAlwaysNotificationSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_notification_always.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -414,11 +416,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithOnlyMinVersion() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_only_min_version.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_only_min_version.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -429,7 +431,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingValidContentWithOnlyMinVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(300,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_only_min_version.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -440,11 +442,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenVersionIsAlreadyNotified() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -455,7 +457,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenVersionIsAlreadyNotifiedSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(245,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -466,11 +468,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenUpdateShouldBeMade() {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_no_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_no_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -482,7 +484,7 @@ public class PrinceOfVersionsTest {
     public void testCheckingWhenUpdateShouldBeMadeSync() throws Throwable {
         Storage storage = new MockStorage();
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), new MockApplicationConfiguration(200,
-                16));
+            16));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_no_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -497,11 +499,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(),
-                appConfig, Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            appConfig, Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -515,7 +517,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -530,11 +532,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -549,7 +551,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_single_sdk_value.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -564,11 +566,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -582,7 +584,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_huge_sdk_values.json"));
     }
 
@@ -593,11 +595,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -612,7 +614,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -627,11 +629,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -646,7 +648,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_downgrading_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -661,11 +663,11 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_huge_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -679,7 +681,7 @@ public class PrinceOfVersionsTest {
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(appConfig);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), appConfig,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_huge_sdk_values.json"));
     }
 
@@ -687,14 +689,14 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValue() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -706,11 +708,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValueSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_single_sdk_value.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -722,15 +724,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValueAndHigherInitialVersion() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_single_sdk_value.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -742,11 +744,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSingleSdkValueAndHigherInitialVersionSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(241,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_single_sdk_value.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -758,15 +760,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithSdkValues() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(140,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_mandatory_update.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_mandatory_update.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -778,11 +780,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithSdkValuesSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(140,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_mandatory_update.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
@@ -794,15 +796,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndTheSameVersions() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(245,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -813,11 +815,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndTheSameVersionsSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(245,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
@@ -828,15 +830,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndWithDifferentVersions() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(244,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -848,11 +850,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndWithDifferentVersionsSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(244,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full_b_with_sdk_values.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);
@@ -864,15 +866,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndIncreaseInMinor() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_full_with_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_full_with_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -883,11 +885,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithSdkValuesAndIncreaseInMinorSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_full_with_sdk_values.json"));
     }
 
@@ -895,15 +897,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithHighSdkValuesAndIncreaseInMinor() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_big_increase_in_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_big_increase_in_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -914,11 +916,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithHighSdkValuesAndIncreaseInMinorSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(230,
-                16);
+            16);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_big_increase_in_sdk_values.json"));
     }
 
@@ -926,15 +928,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithDeviceThatHasVeryLowMinSdk() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(100,
-                12);
+            12);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_same_sdk_values.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_same_sdk_values.json"),
+            callback
         );
 
         verify(callback, times(0)).onSuccess(any(UpdateResult.class));
@@ -945,11 +947,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingMandatoryUpdateWithDeviceThatHasVeryLowMinSdkSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(100,
-                12);
+            12);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_same_sdk_values.json"));
     }
 
@@ -957,15 +959,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWithBigMinimumVersionMinSdk() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200,
-                23);
+            23);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -978,16 +980,16 @@ public class PrinceOfVersionsTest {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(200, 23);
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(
-                storage,
-                new SingleThreadExecutor(),
-                applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(
-                        DEFAULT_OS_VERSION,
-                        new MockDefaultRequirementChecker(applicationConfiguration)
-                )
+            storage,
+            new SingleThreadExecutor(),
+            applicationConfiguration,
+            Collections.<String, RequirementChecker>singletonMap(
+                DEFAULT_OS_VERSION,
+                new MockDefaultRequirementChecker(applicationConfiguration)
+            )
         );
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk"
-                + ".json"));
+            + ".json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED);
         assertThat(result.getUpdateVersion()).isEqualTo(211);
@@ -998,15 +1000,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDate() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-                20);
+            20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -1017,13 +1019,13 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDateSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-                20);
+            20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_with_big_minimum_version_min_sdk"
-                + ".json"));
+            + ".json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE);
         assertThat(result.getUpdateVersion()).isEqualTo(211);
@@ -1033,15 +1035,15 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDateAndNoMandatoryUpdateIsNotDefined() {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-                20);
+            20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         princeOfVersions.checkForUpdatesInternal(
-                new SingleThreadExecutor(),
-                new ResourceFileLoader("valid_update_no_min_version.json"),
-                callback
+            new SingleThreadExecutor(),
+            new ResourceFileLoader("valid_update_no_min_version.json"),
+            callback
         );
 
         verify(callback, times(1)).onSuccess(any(UpdateResult.class));
@@ -1052,11 +1054,11 @@ public class PrinceOfVersionsTest {
     public void testCheckingOptionalUpdateWhenUserIsUpToDateAndNoMandatoryUpdateIsNotDefinedSync() throws Throwable {
         Storage storage = new MockStorage();
         MockApplicationConfiguration applicationConfiguration = new MockApplicationConfiguration(211,
-                20);
+            20);
         MockDefaultRequirementChecker checker = new MockDefaultRequirementChecker(applicationConfiguration);
 
         PrinceOfVersions princeOfVersions = new PrinceOfVersions(storage, new SingleThreadExecutor(), applicationConfiguration,
-                Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
+            Collections.<String, RequirementChecker>singletonMap(DEFAULT_OS_VERSION, checker));
         UpdateResult result = princeOfVersions.checkForUpdates(new ResourceFileLoader("valid_update_no_min_version.json"));
 
         assertThat(result.getStatus()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE);

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/RequirementsProcessorTest.java
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/RequirementsProcessorTest.java
@@ -1,0 +1,59 @@
+package co.infinum.princeofversions;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequirementsProcessorTest {
+
+    @Test
+    public void checkRequiredOsVersionWhenGreaterThanDevice() {
+        Map<String, RequirementChecker> checkers = new HashMap<>();
+        checkers.put(
+            PrinceOfVersionsDefaultRequirementsChecker.KEY,
+            new PrinceOfVersionsDefaultRequirementsChecker(new MockApplicationVersionProvider(23))
+        );
+        PrinceOfVersionsRequirementsProcessor processor = new PrinceOfVersionsRequirementsProcessor(checkers);
+
+        Map<String, String> requirements = new HashMap<>();
+        requirements.put(PrinceOfVersionsDefaultRequirementsChecker.KEY, "25");
+        boolean result = processor.areRequirementsSatisfied(requirements);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void checkRequiredOsVersionWhenLessThanDevice() {
+        Map<String, RequirementChecker> checkers = new HashMap<>();
+        checkers.put(
+            PrinceOfVersionsDefaultRequirementsChecker.KEY,
+            new PrinceOfVersionsDefaultRequirementsChecker(new MockApplicationVersionProvider(25))
+        );
+        PrinceOfVersionsRequirementsProcessor processor = new PrinceOfVersionsRequirementsProcessor(checkers);
+
+        Map<String, String> requirements = new HashMap<>();
+        requirements.put(PrinceOfVersionsDefaultRequirementsChecker.KEY, "23");
+        boolean result = processor.areRequirementsSatisfied(requirements);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void checkRequiredOsVersionWhenEqualToDevice() {
+        Map<String, RequirementChecker> checkers = new HashMap<>();
+        checkers.put(
+            PrinceOfVersionsDefaultRequirementsChecker.KEY,
+            new PrinceOfVersionsDefaultRequirementsChecker(new MockApplicationVersionProvider(23))
+        );
+        PrinceOfVersionsRequirementsProcessor processor = new PrinceOfVersionsRequirementsProcessor(checkers);
+
+        Map<String, String> requirements = new HashMap<>();
+        requirements.put(PrinceOfVersionsDefaultRequirementsChecker.KEY, "23");
+        boolean result = processor.areRequirementsSatisfied(requirements);
+
+        assertThat(result).isTrue();
+    }
+}

--- a/queen-of-versions/CHANGELOG.md
+++ b/queen-of-versions/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 0.2.0
 
+_2020-08-28_
+
+- PrinceOfVersions to version 4.0.2
+
+## Version 0.2.0
+
 _2020-06-05_
 
 - com.google.android.play:core to version 1.7.2

--- a/queen-of-versions/CHANGELOG.md
+++ b/queen-of-versions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.2.0
+## Version 0.3.0
 
 _2020-08-28_
 

--- a/queen-of-versions/README.md
+++ b/queen-of-versions/README.md
@@ -8,7 +8,7 @@ Library checks update availability using In-App updates.
 ## Getting via jcenter
 
 ```groovy
-implementation 'co.infinum:queen-of-versions:0.2.0'
+implementation 'co.infinum:queen-of-versions:0.3.0'
 ```
 
 ## Features

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@ def build = [
 
 def versions = [
         prince   : '4.0.2',
-        queen    : '0.2.0',
+        queen    : '0.3.0',
         semver   : '0.9.0',
         appcompat: '1.1.0',
         findbugs : '3.0.1'

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@ def build = [
 ]
 
 def versions = [
-        prince   : '4.0.1',
+        prince   : '4.0.2',
         queen    : '0.2.0',
         semver   : '0.9.0',
         appcompat: '1.1.0',


### PR DESCRIPTION
Default requirements checkers that PrinceOfVersions supports are from now on integrated even when using constructor to create instance of the PrinceOfVersions class.