### PR TITLE
Replace personal publishing info with Infinum's info

### DIFF
--- a/maven-publish.gradle
+++ b/maven-publish.gradle
@@ -70,16 +70,15 @@ afterEvaluate {
                             url.set("https://github.com/infinum/Android-Prince-of-Versions/blob/master/LICENSE")
                         }
                     }
+                    organization {
+                        name = 'Infinum Inc.'
+                        url = 'https://infinum.com'
+                    }
                     developers {
                         developer {
-                            id = 'NikoPelicaric'
-                            name = 'Niko Pelicaric'
-                            email = 'niko.pelicaric@infinum.com'
-                        }
-                        developer {
-                            id = 'antunflas'
-                            name = 'Antun Flaš'
-                            email = 'antun.flas@infinum.com'
+                            id = 'Infinum'
+                            name = 'Infinum Inc.'
+                            url = 'https://infinum.com'
                         }
                     }
                     scm {


### PR DESCRIPTION
Publishing info should reflect that Infinum is developer/maintainer of library. That info is shown when fetching licences with tools like: https://github.com/mikepenz/AboutLibraries

IMO we should only have organization info. But I found that some tools that collect info for libs sometimes read only developers info and sometimes developer and organization infos are interchangeable.
This is why I added both developer and organization