### PR TITLE
Setup comprehensive test codebase

### DIFF
--- a/maven-publish.gradle
+++ b/maven-publish.gradle
@@ -56,7 +56,7 @@ afterEvaluate {
                 artifactId = props.artifact
                 version = props.version
 
-                artifact("${getLayout().getBuildDirectory()}/outputs/aar/${project.getName()}-release.aar")
+                artifact(layout.buildDirectory.file("outputs/aar/${project.name}-release.aar"))
 
                 artifact sourcesJar
                 artifact javadocsJar

--- a/prince-of-versions/build.gradle
+++ b/prince-of-versions/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     testImplementation deps.junit
     testImplementation deps.mockito
+    testImplementation deps.mockito_inline
     testImplementation deps.mockwebserver
     testImplementation deps.assertj
     testImplementation deps.json

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/ApplicationConfigurationImplTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/ApplicationConfigurationImplTest.kt
@@ -1,0 +1,62 @@
+package co.infinum.princeofversions
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class ApplicationConfigurationImplTest {
+
+    @Test
+    fun testVersionIsResolvedFromPackageManager() {
+        val mockContext = mock(Context::class.java)
+        val mockPackageManager = mock(PackageManager::class.java)
+        val mockPackageInfo = PackageInfo()
+        mockPackageInfo.versionCode = 123
+        val packageName = "co.infinum.princeofversions.test"
+
+        `when`(mockContext.packageName).thenReturn(packageName)
+        `when`(mockContext.packageManager).thenReturn(mockPackageManager)
+        `when`(mockPackageManager.getPackageInfo(packageName, 0)).thenReturn(mockPackageInfo)
+
+        val appConfig = ApplicationConfigurationImpl(mockContext)
+
+        assertThat(appConfig.version()).isEqualTo(123)
+    }
+
+    @Test
+    fun testSdkVersionIsResolvedFromBuild() {
+        val mockContext = mock(Context::class.java)
+        val mockPackageManager = mock(PackageManager::class.java)
+        val mockPackageInfo = PackageInfo()
+        val packageName = "co.infinum.princeofversions.test"
+
+        `when`(mockContext.packageName).thenReturn(packageName)
+        `when`(mockContext.packageManager).thenReturn(mockPackageManager)
+        `when`(mockPackageManager.getPackageInfo(packageName, 0)).thenReturn(mockPackageInfo)
+
+        val appConfig = ApplicationConfigurationImpl(mockContext)
+
+        assertThat(appConfig.sdkVersionCode()).isEqualTo(Build.VERSION.SDK_INT)
+    }
+
+    @Test
+    fun testConstructorThrowsExceptionOnNameNotFound() {
+        val mockContext = mock(Context::class.java)
+        val mockPackageManager = mock(PackageManager::class.java)
+        val packageName = "co.infinum.princeofversions.test"
+
+        `when`(mockContext.packageName).thenReturn(packageName)
+        `when`(mockContext.packageManager).thenReturn(mockPackageManager)
+        `when`(mockPackageManager.getPackageInfo(packageName, 0)).thenThrow(PackageManager.NameNotFoundException())
+
+        assertThatThrownBy { ApplicationConfigurationImpl(mockContext) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Could not find package name")
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/CheckResultTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/CheckResultTestRefactored.kt
@@ -1,0 +1,300 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+
+class CheckResultTestRefactored {
+
+    private companion object Companion {
+        private const val DEFAULT_REQUIRED_VERSION = 1
+        private const val DEFAULT_LAST_VERSION_AVAILABLE = 1
+        private val DEFAULT_REQUIREMENTS: Map<String, String> = emptyMap()
+        private const val DEFAULT_VERSION = 1
+        private val DEFAULT_METADATA: Map<String, String> = emptyMap()
+        private val updateInfo = UpdateInfo(
+            DEFAULT_REQUIRED_VERSION,
+            DEFAULT_LAST_VERSION_AVAILABLE,
+            DEFAULT_REQUIREMENTS,
+            DEFAULT_VERSION,
+            NotificationType.ALWAYS
+        )
+    }
+
+    @Test
+    fun checkHasUpdateMandatory() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.hasUpdate()).isTrue()
+    }
+
+    @Test
+    fun checkHasUpdateOptionalAlways() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.hasUpdate()).isTrue()
+    }
+
+    @Test
+    fun checkHasUpdateOptionalOnce() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ONCE, DEFAULT_METADATA, updateInfo)
+        assertThat(result.hasUpdate()).isTrue()
+    }
+
+    @Test
+    fun checkHasUpdateMandatoryWithNulls() {
+        val result = CheckResult.mandatoryUpdate(null, null, updateInfo)
+        assertThat(result.hasUpdate()).isTrue()
+    }
+
+    @Test
+    fun checkHasUpdateOptionalAlwaysWithNulls() {
+        val result = CheckResult.optionalUpdate(null, NotificationType.ALWAYS, null, updateInfo)
+        assertThat(result.hasUpdate()).isTrue()
+    }
+
+    @Test
+    fun checkHasUpdateOptionalOnceWithNulls() {
+        val result = CheckResult.optionalUpdate(null, NotificationType.ONCE, null, updateInfo)
+        assertThat(result.hasUpdate()).isTrue()
+    }
+
+    @Test
+    fun checkHasNoUpdate() {
+        val result = CheckResult.noUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.hasUpdate()).isFalse()
+    }
+
+    @Test
+    fun checkHasNoUpdateWithNulls() {
+        val result = CheckResult.noUpdate(null, null, updateInfo)
+        assertThat(result.hasUpdate()).isFalse()
+    }
+
+    @Test
+    fun checkGetUpdateVersion() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.updateVersion).isEqualTo(DEFAULT_VERSION)
+    }
+
+    @Test
+    fun checkIsOptionalMandatory() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.isOptional).isFalse()
+    }
+
+    @Test
+    fun checkIsOptionalOptionalAlways() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.isOptional).isTrue()
+    }
+
+    @Test
+    fun checkIsOptionalOptionalOnce() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ONCE, DEFAULT_METADATA, updateInfo)
+        assertThat(result.isOptional).isTrue()
+    }
+
+    @Test
+    fun checkIsOptionalMandatoryWithNulls() {
+        val result = CheckResult.mandatoryUpdate(null, null, updateInfo)
+        assertThat(result.isOptional).isFalse()
+    }
+
+    @Test
+    fun checkIsOptionalOptionalAlwaysWithNulls() {
+        val result = CheckResult.optionalUpdate(null, NotificationType.ALWAYS, null, updateInfo)
+        assertThat(result.isOptional).isTrue()
+    }
+
+    @Test
+    fun checkIsOptionalOptionalOnceWithNulls() {
+        val result = CheckResult.optionalUpdate(null, NotificationType.ONCE, null, updateInfo)
+        assertThat(result.isOptional).isTrue()
+    }
+
+    @Test
+    fun checkIsOptionalWhenNoUpdate() {
+        val result = CheckResult.noUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThatThrownBy { result.isOptional }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("There is no update available.")
+    }
+
+    @Test
+    fun checkIsOptionalWhenNoUpdateWithNulls() {
+        val result = CheckResult.noUpdate(null, null, updateInfo)
+        assertThatThrownBy { result.isOptional }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("There is no update available.")
+    }
+
+    @Test
+    fun checkNotificationTypeMandatory() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThatThrownBy { result.notificationType }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("There is no optional update available.")
+    }
+
+    @Test
+    fun checkNotificationTypelOptionalAlways() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.notificationType).isEqualTo(NotificationType.ALWAYS)
+    }
+
+    @Test
+    fun checkNotificationTypeOptionalOnce() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ONCE, DEFAULT_METADATA, updateInfo)
+        assertThat(result.notificationType).isEqualTo(NotificationType.ONCE)
+    }
+
+    @Test
+    fun checkNotificationTypeWhenNoUpdate() {
+        val result = CheckResult.noUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThatThrownBy { result.notificationType }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("There is no update available.")
+    }
+
+    @Test
+    fun checkNotificationTypeWhenNoUpdateWithNulls() {
+        val result = CheckResult.noUpdate(null, null, updateInfo)
+        assertThatThrownBy { result.notificationType }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("There is no update available.")
+    }
+
+    @Test
+    fun checkStatusMandatory() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.status()).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED)
+    }
+
+    @Test
+    fun checkStatusOptional() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.status()).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE)
+    }
+
+    @Test
+    fun checkStatusNoUpdate() {
+        val result = CheckResult.noUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.status()).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE)
+    }
+
+    @Test
+    fun checkMetadataMandatory() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.metadata()).isEqualTo(DEFAULT_METADATA)
+    }
+
+    @Test
+    fun checkMetadataOptional() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.metadata()).isEqualTo(DEFAULT_METADATA)
+    }
+
+    @Test
+    fun checkMetadataNoUpdate() {
+        val result = CheckResult.noUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.metadata()).isEqualTo(DEFAULT_METADATA)
+    }
+
+    @Test
+    fun checkUpdateInfoMandatoryUpdate() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info).isEqualTo(updateInfo)
+    }
+
+    @Test
+    fun checkUpdateInfoOptionalUpdate() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info).isEqualTo(updateInfo)
+    }
+
+    @Test
+    fun checkUpdateInfoRequiredVersionMandatoryUpdate() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.requiredVersion).isEqualTo(DEFAULT_REQUIRED_VERSION)
+    }
+
+    @Test
+    fun checkUpdateInfoRequiredVersionOptionalUpdate() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.requiredVersion).isEqualTo(DEFAULT_REQUIRED_VERSION)
+    }
+
+    @Test
+    fun checkUpdateInfoLastVersionAvailableMandatoryUpdate() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.lastVersionAvailable).isEqualTo(DEFAULT_LAST_VERSION_AVAILABLE)
+    }
+
+    @Test
+    fun checkUpdateInfoLastVersionAvailableOptionalUpdate() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.lastVersionAvailable).isEqualTo(DEFAULT_LAST_VERSION_AVAILABLE)
+    }
+
+    @Test
+    fun checkUpdateInfoInstalledVersionMandatoryUpdate() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.installedVersion).isEqualTo(DEFAULT_VERSION)
+    }
+
+    @Test
+    fun checkUpdateInfoInstalledVersionOptionalUpdate() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.installedVersion).isEqualTo(DEFAULT_VERSION)
+    }
+
+    @Test
+    fun checkUpdateInfoRequirementsMandatoryUpdate() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.requirements).isEqualTo(DEFAULT_REQUIREMENTS)
+    }
+
+    @Test
+    fun checkUpdateInfoRequirementsOptionalUpdate() {
+        val result = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        assertThat(result.info.requirements).isEqualTo(DEFAULT_REQUIREMENTS)
+    }
+
+    @Test
+    fun checkEqualsAndHashCodeContract() {
+        val mandatoryResult1 = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        val mandatoryResult2 = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        val mandatoryResult3 = CheckResult.mandatoryUpdate(2, DEFAULT_METADATA, updateInfo)
+        val optionalResult1 = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+        val optionalResult2 = CheckResult.optionalUpdate(DEFAULT_VERSION, NotificationType.ALWAYS, DEFAULT_METADATA, updateInfo)
+
+        // Test equals contract
+        assertThat(mandatoryResult1).isEqualTo(mandatoryResult1) // Reflexive
+        assertThat(mandatoryResult1).isEqualTo(mandatoryResult2) // Symmetric
+        assertThat(mandatoryResult2).isEqualTo(mandatoryResult1)
+        assertThat(mandatoryResult1).isNotEqualTo(mandatoryResult3)
+        assertThat(mandatoryResult1).isNotEqualTo(optionalResult1)
+        assertThat(mandatoryResult1.equals("a string")).isFalse()
+        assertThat(mandatoryResult1.equals(null)).isFalse()
+
+        // Test hashCode contract
+        // For optional updates, hashcode should be consistent
+        assertThat(optionalResult1.hashCode()).isEqualTo(optionalResult2.hashCode())
+
+        // For mandatory updates, hashCode throws an exception - this is a bug in the class, but the test should document it
+        // TODO - check whether this bug is of real concern in the actual implementation and context of usage - if so fix it
+        assertThatThrownBy { mandatoryResult1.hashCode() }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("There is no optional update available.")
+    }
+
+    @Test
+    fun checkToStringContent() {
+        val result = CheckResult.mandatoryUpdate(DEFAULT_VERSION, DEFAULT_METADATA, updateInfo)
+        val resultString = result.toString()
+
+        assertThat(resultString).contains(UpdateStatus.REQUIRED_UPDATE_NEEDED.toString())
+        assertThat(resultString).contains(updateInfo.toString())
+        assertThat(resultString).contains(DEFAULT_METADATA.toString())
+        assertThat(resultString).contains("null") // notificationType is null for mandatory
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/ExecutorUpdaterCallbackTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/ExecutorUpdaterCallbackTest.kt
@@ -1,0 +1,36 @@
+package co.infinum.princeofversions
+
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import java.util.concurrent.Executor
+
+class ExecutorUpdaterCallbackTest {
+
+    @Test
+    fun testOnSuccessIsCalledOnExecutor() {
+        val mockCallback = mock(UpdaterCallback::class.java)
+        val syncExecutor = Executor { it.run() }
+        val executorCallback = ExecutorUpdaterCallback(mockCallback, syncExecutor)
+        val mockResult = mock(UpdateResult::class.java)
+
+        executorCallback.onSuccess(mockResult)
+
+        verify(mockCallback).onSuccess(mockResult)
+        verifyNoMoreInteractions(mockCallback)
+    }
+
+    @Test
+    fun testOnErrorIsCalledOnExecutor() {
+        val mockCallback = mock(UpdaterCallback::class.java)
+        val syncExecutor = Executor { it.run() }
+        val executorCallback = ExecutorUpdaterCallback(mockCallback, syncExecutor)
+        val mockError = mock(Throwable::class.java)
+
+        executorCallback.onError(mockError)
+
+        verify(mockCallback).onError(mockError)
+        verifyNoMoreInteractions(mockCallback)
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/InteractorTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/InteractorTestRefactored.kt
@@ -1,0 +1,169 @@
+package co.infinum.princeofversions
+
+import co.infinum.princeofversions.mocks.MockApplicationConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class InteractorTestRefactored {
+
+    private companion object Companion {
+        private const val DEFAULT_LOADER_RESULT = ""
+    }
+
+    @Mock
+    private lateinit var loader: Loader
+
+    @Mock
+    private lateinit var configurationParser: ConfigurationParser
+
+    private lateinit var interactor: Interactor
+
+    @Before
+    fun setUp() {
+        interactor = InteractorImpl(configurationParser)
+        `when`(loader.load()).thenReturn(DEFAULT_LOADER_RESULT)
+    }
+
+    @After
+    fun tearDown() {
+        // Not strictly necessary with MockitoJUnitRunner, but good practice
+    }
+
+    @Test
+    fun checkMandatoryUpdate() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(2)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.mandatoryUpdate(config.mandatoryVersion, config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkMandatoryUpdateWhenNoUpdateAvailable() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(1)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.noUpdate(appConfig.version(), config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkMandatoryUpdateWhenNoMandatoryOrOptionalUpdateAvailable() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(1)
+            .withOptionalVersion(1)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.noUpdate(appConfig.version(), config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkMandatoryUpdateWithOptionalVersion() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(2)
+            .withOptionalVersion(3)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.mandatoryUpdate(config.optionalVersion, config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkMandatoryUpdateWhenMandatoryAndOptionalAreEqual() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(2)
+            .withOptionalVersion(2)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.mandatoryUpdate(config.mandatoryVersion, config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkOptionalUpdate() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withOptionalVersion(2)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.optionalUpdate(config.optionalVersion, NotificationType.ONCE, config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkOptionalUpdateWhenNoUpdateAvailable() {
+        val config = PrinceOfVersionsConfig.Builder()
+            .withOptionalVersion(1)
+            .build()
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        val result = interactor.check(loader, appConfig)
+
+        verify(loader, times(1)).load()
+        verify(configurationParser, times(1)).parse(DEFAULT_LOADER_RESULT)
+        val expectedInfo = UpdateInfo(config.mandatoryVersion, config.optionalVersion, config.requirements, appConfig.version(), config.optionalNotificationType)
+        assertThat(result).isEqualTo(CheckResult.noUpdate(appConfig.version(), config.metadata, expectedInfo))
+    }
+
+    @Test
+    fun checkThrowsExceptionWhenNoVersionAvailable() {
+        val config = PrinceOfVersionsConfig.Builder().build() // No versions set
+        `when`(configurationParser.parse(anyString())).thenReturn(config)
+        val appConfig = MockApplicationConfiguration(1, 1)
+
+        assertThatThrownBy { interactor.check(loader, appConfig) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Both mandatory and optional version are null.")
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/JsonConfigurationParserTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/JsonConfigurationParserTestRefactored.kt
@@ -1,0 +1,296 @@
+package co.infinum.princeofversions
+
+import co.infinum.princeofversions.mocks.MockDefaultRequirementChecker
+import co.infinum.princeofversions.util.ResourceUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+
+class JsonConfigurationParserTestRefactored {
+
+    private lateinit var parser: JsonConfigurationParser
+
+    @Before
+    fun setUp() {
+        val defaultRequirements: Map<String, RequirementChecker> = mapOf(
+            PrinceOfVersionsDefaultRequirementsChecker.KEY to MockDefaultRequirementChecker(21)
+        )
+        parser = JsonConfigurationParser(PrinceOfVersionsRequirementsProcessor(defaultRequirements))
+    }
+
+    @Test
+    fun checkEmptyJsonToStringMap() {
+        assertThat(parser.jsonObjectToMap(JSONObject("{}"))).isEmpty()
+    }
+
+    @Test
+    fun checkJsonToStringMap() {
+        val map = parser.jsonObjectToMap(JSONObject(ResourceUtils.readFromFile("json_obj_string.json")))
+        assertThat(map).isEqualTo(mapOf("key1" to "value1", "key2" to "value2"))
+    }
+
+    @Test
+    fun checkJsonToStringMapWithNull() {
+        val map = parser.jsonObjectToMap(JSONObject(ResourceUtils.readFromFile("json_obj_string_with_null.json")))
+        assertThat(map).isEqualTo(mapOf("key1" to null, "key2" to "value2"))
+    }
+
+    @Test
+    fun checkComplexJsonToStringMap() {
+        val map = parser.jsonObjectToMap(JSONObject(ResourceUtils.readFromFile("json_obj_string_complex.json")))
+        assertThat(map).isEqualTo(
+            mapOf(
+                "key1" to "value1",
+                "key2" to "value2",
+                "key3" to "true",
+                "key4" to "0",
+                "key5" to "[0,1]",
+                "key6" to "{}"
+            )
+        )
+    }
+
+    @Test
+    fun invalidUpdateNoAndroidKey() {
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("invalid_update_no_android.json")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Config resource does not contain android key")
+    }
+
+    @Test
+    fun invalidUpdateNotJson() {
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("invalid_update_no_json.json")) }
+            .isInstanceOf(JSONException::class.java)
+    }
+
+    @Test
+    fun malformedJson() {
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("malformed_json.json")) }
+            .isInstanceOf(JSONException::class.java)
+    }
+
+    @Test
+    fun validUpdateFullJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateFullWithMetadataJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .withMetadata(mapOf("key1" to "value1", "key2" to "value2"))
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateFullWithEmptyMetadataJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_empty.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .withMetadata(emptyMap())
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateFullWithMetadataMalformed() {
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_malformed.json")) }
+            .isInstanceOf(JSONException::class.java)
+    }
+
+    @Test
+    fun validUpdateFullWithNullMetadataJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_metadata_null.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .withMetadata(emptyMap())
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateFullWithSdkValuesJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_with_sdk_values.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(240)
+            .withRequirements(mapOf("required_os_version" to "17"))
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun noMandatoryVersionJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_no_min_version.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateNoNotificationJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_no_notification.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ONCE)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateAlwaysNotificationJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_notification_always.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withOptionalNotificationType(NotificationType.ALWAYS)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun mandatoryVersionNullJson() {
+        val result = parser.parse(ResourceUtils.readFromFile("valid_update_null_min_version.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(null)
+            .withOptionalVersion(245)
+            .build()
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateOnlyMandatoryJson() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_only_min_version.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateWithJsonArray() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateWithMergingMetadata() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_metadata.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withMetadata(mapOf("x" to "10", "z" to "3"))
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun validUpdateWithOverridingMetadata() {
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_overriding_metadata.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(245)
+            .withMetadata(mapOf("x" to "10"))
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun invalidUpdateWithStringLatestVersion() {
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("invalid_update_with_string_version.json")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun invalidUpdateWithIntNotification() {
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("invalid_update_with_int_notification_type.json")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun validUpdateWithRequirements() {
+        val checker = MockDefaultRequirementChecker(13)
+        val requirements: Map<String, RequirementChecker> = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker)
+        val processor = PrinceOfVersionsRequirementsProcessor(requirements)
+        val parser = JsonConfigurationParser(processor)
+        val config = parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_requirements.json"))
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123)
+            .withOptionalVersion(246)
+            .withRequirements(mapOf("required_os_version" to "13"))
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun invalidDataInDefaultRequirementChecker() {
+        val checker = MockDefaultRequirementChecker(13)
+        assertThatThrownBy { checker.checkRequirements("not integer") }
+            .isInstanceOf(Throwable::class.java)
+    }
+
+    @Test
+    fun checkAndroid2KeyIsUsedOverAndroidKey() {
+        val json = """
+            {
+                "android2": { "required_version": 999 },
+                "android": { "required_version": 123 }
+            }
+        """.trimIndent()
+        val config = parser.parse(json)
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(999) // Version from 'android2'
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun checkAndroidKeyIsUsedAsFallback() {
+        val json = """
+            {
+                "android": { "required_version": 123 }
+            }
+        """.trimIndent()
+        val config = parser.parse(json)
+        val expected = PrinceOfVersionsConfig.Builder()
+            .withMandatoryVersion(123) // Version from 'android'
+            .build()
+        assertThat(config).isEqualTo(expected)
+    }
+
+    @Test
+    fun checkRequirementsNotSatisfiedInArrayThrowsException() {
+        val checker = MockDefaultRequirementChecker(10) // Device SDK is 10
+        val requirements: Map<String, RequirementChecker> = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker)
+        val processor = PrinceOfVersionsRequirementsProcessor(requirements)
+        val parser = JsonConfigurationParser(processor)
+        // JSON requires SDK 13 and 21, neither is satisfied
+        assertThatThrownBy { parser.parse(ResourceUtils.readFromFile("valid_update_full_array_with_requirements.json")) }
+            .isInstanceOf(RequirementsNotSatisfiedException::class.java)
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/LazyTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/LazyTest.kt
@@ -1,0 +1,64 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+// Interface for our test object
+internal interface ValueProvider {
+    fun getValue(): String
+}
+
+class LazyTest {
+
+    @Test
+    fun testLazyInitializationLifecycle() {
+        var initializationCounter = 0
+        val creator = Callable<ValueProvider> {
+            initializationCounter++
+            object : ValueProvider {
+                override fun getValue(): String = "my-value"
+            }
+        }
+
+        val lazyValue = Lazy.create(ValueProvider::class.java, creator)
+
+        assertThat(initializationCounter).isEqualTo(0)
+
+        assertThat(lazyValue.getValue()).isEqualTo("my-value")
+        assertThat(initializationCounter).isEqualTo(1)
+
+        assertThat(lazyValue.getValue()).isEqualTo("my-value")
+        assertThat(initializationCounter).isEqualTo(1)
+    }
+
+    @Test
+    fun testLazyInitializationIsThreadSafe() {
+        val initializationCounter = AtomicInteger(0)
+        val creator = Callable<ValueProvider> {
+            Thread.sleep(100)
+            initializationCounter.incrementAndGet()
+            object : ValueProvider {
+                override fun getValue(): String = "my-value"
+            }
+        }
+
+        val lazyValue = Lazy.create(ValueProvider::class.java, creator)
+        val threadCount = 10
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        for (i in 1..threadCount) {
+            executor.submit {
+                lazyValue.getValue()
+            }
+        }
+
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+
+        assertThat(initializationCounter.get()).isEqualTo(1)
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/NetworkLoaderTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/NetworkLoaderTestRefactored.kt
@@ -1,0 +1,89 @@
+package co.infinum.princeofversions
+
+import co.infinum.princeofversions.util.ResourceUtils
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.IOException
+import java.net.SocketTimeoutException
+
+@RunWith(MockitoJUnitRunner::class)
+class NetworkLoaderTestRefactored {
+
+    private lateinit var mockWebServer: MockWebServer
+
+    @Before
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+    }
+
+    @After
+    fun cleanup() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun networkNormalTest() {
+        val filename = "valid_update_full.json"
+        val responseBody = ResourceUtils.readFromFile(filename)
+        val response = MockResponse().setBody(responseBody).setResponseCode(200)
+        mockWebServer.enqueue(response)
+
+        val networkLoader: Loader = NetworkLoader(mockWebServer.url("/").toString())
+        val content = networkLoader.load()
+
+        assertJsonEquals(content, responseBody)
+    }
+
+    @Test
+    fun networkTimeoutTest() {
+        val networkLoader: Loader = NetworkLoader(mockWebServer.url("/").toString(), 1)
+        assertThatThrownBy { networkLoader.load() }
+            .isInstanceOf(SocketTimeoutException::class.java)
+    }
+
+    @Test
+    fun networkJsonMalformedTest() {
+        val filename = "malformed_json.json"
+        val responseBody = ResourceUtils.readFromFile(filename)
+        val response = MockResponse().setBody(responseBody).setResponseCode(200)
+        mockWebServer.enqueue(response)
+
+        val networkLoader: Loader = NetworkLoader(mockWebServer.url("/").toString())
+        val content = networkLoader.load()
+
+        assertJsonEquals(content, responseBody)
+    }
+
+    @Test
+    fun networkResponseMissingTest() {
+        val response = MockResponse().setResponseCode(200) // No body
+        mockWebServer.enqueue(response)
+
+        val networkLoader: Loader = NetworkLoader(mockWebServer.url("/").toString())
+        val content = networkLoader.load()
+
+        assertJsonEquals(content, "")
+    }
+
+    @Test
+    fun networkErrorResponseTest() {
+        val response = MockResponse().setResponseCode(404)
+        mockWebServer.enqueue(response)
+
+        val networkLoader: Loader = NetworkLoader(mockWebServer.url("/").toString())
+        assertThatThrownBy { networkLoader.load() }
+            .isInstanceOf(IOException::class.java)
+    }
+
+    private fun assertJsonEquals(actual: String, expected: String) {
+        assertThat(actual.replace("\n", "")).isEqualTo(expected.replace("\n", ""))
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/PresenterTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/PresenterTestRefactored.kt
@@ -1,0 +1,179 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.concurrent.Executor
+
+@RunWith(MockitoJUnitRunner::class)
+class PresenterTestRefactored {
+
+    @Mock
+    private lateinit var interactor: Interactor
+
+    @Mock
+    private lateinit var storage: Storage
+
+    @Mock
+    private lateinit var loader: Loader
+
+    @Mock
+    private lateinit var appConfig: ApplicationConfiguration
+
+    @Mock
+    private lateinit var updateInfo: UpdateInfo
+
+    private lateinit var presenter: PresenterImpl
+
+    private val defaultMetadata: Map<String, String> = emptyMap()
+
+    @Before
+    fun setUp() {
+        presenter = PresenterImpl(interactor, storage)
+    }
+
+    @Test
+    fun testMandatoryUpdate() {
+        val checkResult = CheckResult.mandatoryUpdate(10, defaultMetadata, updateInfo)
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenReturn(checkResult)
+
+        val result = presenter.run(loader, appConfig)
+
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.REQUIRED_UPDATE_NEEDED, 10)
+        assertThat(result).isEqualTo(expected)
+        verify(storage, times(1)).rememberLastNotifiedVersion(checkResult.updateVersion)
+    }
+
+    @Test
+    fun testNoUpdate() {
+        val checkResult = CheckResult.noUpdate(10, defaultMetadata, updateInfo)
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenReturn(checkResult)
+
+        val result = presenter.run(loader, appConfig)
+
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.NO_UPDATE_AVAILABLE, checkResult.updateVersion)
+        assertThat(result).isEqualTo(expected)
+        verify(storage, never()).rememberLastNotifiedVersion(anyInt())
+    }
+
+    @Test
+    fun testOptionalUpdateFirstTime() {
+        val checkResult = CheckResult.optionalUpdate(12, NotificationType.ONCE, defaultMetadata, updateInfo)
+        `when`(storage.lastNotifiedVersion(null)).thenReturn(null) // First time seeing any update
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenReturn(checkResult)
+
+        val result = presenter.run(loader, appConfig)
+
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.NEW_UPDATE_AVAILABLE, checkResult.updateVersion)
+        assertThat(result).isEqualTo(expected)
+        verify(storage, times(1)).rememberLastNotifiedVersion(checkResult.updateVersion)
+    }
+
+    @Test
+    fun testOptionalUpdateWhenNotNotified() {
+        val checkResult = CheckResult.optionalUpdate(12, NotificationType.ONCE, defaultMetadata, updateInfo)
+        `when`(storage.lastNotifiedVersion(null)).thenReturn(11) // Old version notified
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenReturn(checkResult)
+
+        val result = presenter.run(loader, appConfig)
+
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.NEW_UPDATE_AVAILABLE, checkResult.updateVersion)
+        assertThat(result).isEqualTo(expected)
+        verify(storage, times(1)).rememberLastNotifiedVersion(checkResult.updateVersion)
+    }
+
+    @Test
+    fun testOptionalUpdateNotifiedAlways() {
+        val checkResult = CheckResult.optionalUpdate(12, NotificationType.ALWAYS, defaultMetadata, updateInfo)
+        `when`(storage.lastNotifiedVersion(null)).thenReturn(12) // Same version notified
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenReturn(checkResult)
+
+        val result = presenter.run(loader, appConfig)
+
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.NEW_UPDATE_AVAILABLE, checkResult.updateVersion)
+        assertThat(result).isEqualTo(expected)
+        verify(storage, times(1)).rememberLastNotifiedVersion(checkResult.updateVersion)
+    }
+
+    @Test
+    fun testOptionalUpdateNotifiedOnce() {
+        val checkResult = CheckResult.optionalUpdate(12, NotificationType.ONCE, defaultMetadata, updateInfo)
+        `when`(storage.lastNotifiedVersion(null)).thenReturn(12) // Same version notified
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenReturn(checkResult)
+
+        val result = presenter.run(loader, appConfig)
+
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.NO_UPDATE_AVAILABLE, checkResult.updateVersion)
+        assertThat(result).isEqualTo(expected)
+        verify(storage, never()).rememberLastNotifiedVersion(anyInt())
+    }
+
+    @Test
+    fun testSyncCheckError() {
+        `when`(interactor.check(any(Loader::class.java), any(ApplicationConfiguration::class.java))).thenThrow(IllegalStateException())
+        assertThatThrownBy { presenter.check(loader, appConfig) }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun testAsyncCheckSuccess() {
+        val callback = mock(UpdaterCallback::class.java)
+        val executor = Executor { it.run() }
+        val checkResult = CheckResult.mandatoryUpdate(10, defaultMetadata, updateInfo)
+        val expected = UpdateResult(updateInfo, defaultMetadata, UpdateStatus.REQUIRED_UPDATE_NEEDED, 10)
+        `when`(interactor.check(loader, appConfig)).thenReturn(checkResult)
+
+        presenter.check(loader, executor, callback, appConfig)
+
+        verify(callback, times(1)).onSuccess(expected)
+        verify(callback, never()).onError(any(Throwable::class.java))
+    }
+
+    @Test
+    fun testAsyncCheckError() {
+        val callback = mock(UpdaterCallback::class.java)
+        val executor = Executor { it.run() }
+        val throwable = IllegalStateException()
+        `when`(interactor.check(loader, appConfig)).thenThrow(throwable)
+
+        presenter.check(loader, executor, callback, appConfig)
+
+        verify(callback, never()).onSuccess(any(UpdateResult::class.java))
+        verify(callback, times(1)).onError(throwable)
+    }
+
+    @Test
+    fun testAsyncCheckSuccessIsIgnoredWhenCanceled() {
+        val callback = mock(UpdaterCallback::class.java)
+        val executor = Executor { /* Don't run immediately */ }
+
+        val cancelable = presenter.check(loader, executor, callback, appConfig)
+        cancelable.cancel()
+
+        verify(callback, never()).onSuccess(any(UpdateResult::class.java))
+        verify(callback, never()).onError(any(Throwable::class.java))
+    }
+
+    @Test
+    fun testAsyncCheckErrorIsIgnoredWhenCanceled() {
+        val callback = mock(UpdaterCallback::class.java)
+        val executor = Executor { /* Don't run immediately */ }
+
+        val cancelable = presenter.check(loader, executor, callback, appConfig)
+        cancelable.cancel()
+
+        verify(callback, never()).onSuccess(any(UpdateResult::class.java))
+        verify(callback, never()).onError(any(Throwable::class.java))
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsDefaultNamedPreferenceStorageTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsDefaultNamedPreferenceStorageTest.kt
@@ -1,0 +1,63 @@
+package co.infinum.princeofversions
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class PrinceOfVersionsDefaultNamedPreferenceStorageTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var sharedPreferences: SharedPreferences
+
+    @Mock
+    lateinit var editor: SharedPreferences.Editor
+
+    @Before
+    fun setUp() {
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences)
+        `when`(sharedPreferences.edit()).thenReturn(editor)
+        `when`(editor.putString(anyString(), anyString())).thenReturn(editor)
+    }
+
+    @Test
+    fun testRememberLastNotifiedVersionStoresValue() {
+        val storage = PrinceOfVersionsDefaultNamedPreferenceStorage(context)
+        storage.rememberLastNotifiedVersion(123)
+        verify(editor).putString("PrinceOfVersions_LastNotifiedUpdate", "123")
+        verify(editor).apply()
+    }
+
+    @Test
+    fun testLastNotifiedVersionReturnsStoredValue() {
+        `when`(sharedPreferences.getString("PrinceOfVersions_LastNotifiedUpdate", "456")).thenReturn("123")
+        val storage = PrinceOfVersionsDefaultNamedPreferenceStorage(context)
+        val result = storage.lastNotifiedVersion(456)
+        assertThat(result).isEqualTo(123)
+    }
+
+    @Test
+    fun testLastNotifiedVersionReturnsDefaultWhenNull() {
+        `when`(sharedPreferences.getString("PrinceOfVersions_LastNotifiedUpdate", "789")).thenReturn(null)
+        val storage = PrinceOfVersionsDefaultNamedPreferenceStorage(context)
+        val result = storage.lastNotifiedVersion(789)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun testLastNotifiedVersionReturnsNullOnNumberFormatException() {
+        `when`(sharedPreferences.getString("PrinceOfVersions_LastNotifiedUpdate", "999")).thenReturn("not_a_number")
+        val storage = PrinceOfVersionsDefaultNamedPreferenceStorage(context)
+        val result = storage.lastNotifiedVersion(999)
+        assertThat(result).isNull()
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsDefaultRequirementsCheckerTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsDefaultRequirementsCheckerTest.kt
@@ -1,0 +1,42 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class PrinceOfVersionsDefaultRequirementsCheckerTest {
+
+    @Test
+    fun testCheckRequirementsTrueWhenMinSdkIsLessThanOrEqualToProvided() {
+        val provider = PrinceOfVersionsDefaultRequirementsChecker.ApplicationVersionProvider { 28 }
+        val checker = PrinceOfVersionsDefaultRequirementsChecker(provider)
+
+        assertThat(checker.checkRequirements("27")).isTrue()
+        assertThat(checker.checkRequirements("28")).isTrue()
+    }
+
+    @Test
+    fun testCheckRequirementsFalseWhenMinSdkIsGreaterThanProvided() {
+        val provider = PrinceOfVersionsDefaultRequirementsChecker.ApplicationVersionProvider { 25 }
+        val checker = PrinceOfVersionsDefaultRequirementsChecker(provider)
+
+        assertThat(checker.checkRequirements("26")).isFalse()
+        assertThat(checker.checkRequirements("30")).isFalse()
+    }
+
+    @Test(expected = NumberFormatException::class)
+    fun testCheckRequirementsThrowsExceptionForInvalidInput() {
+        val provider = PrinceOfVersionsDefaultRequirementsChecker.ApplicationVersionProvider { 25 }
+        val checker = PrinceOfVersionsDefaultRequirementsChecker(provider)
+
+        checker.checkRequirements("not_a_number")
+    }
+
+    @Test
+    fun testDefaultConstructorDoesNotThrow() {
+        val checker = PrinceOfVersionsDefaultRequirementsChecker()
+        checker.checkRequirements("1") // Should not throw
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/PrinceOfVersionsTestRefactored.kt
@@ -1,0 +1,184 @@
+package co.infinum.princeofversions
+
+import co.infinum.princeofversions.mocks.MockApplicationConfiguration
+import co.infinum.princeofversions.mocks.MockStorage
+import co.infinum.princeofversions.mocks.ResourceFileLoader
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.IOException
+import java.util.concurrent.Executor
+
+@RunWith(MockitoJUnitRunner::class)
+class PrinceOfVersionsTestRefactored {
+
+    @Mock
+    private lateinit var callback: UpdaterCallback
+
+    @Test
+    fun testMandatoryUpdate() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(100, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = ResourceFileLoader("valid_update_full.json")
+
+        val result = pov.checkForUpdates(loader)
+
+        assertThat(result.status).isEqualTo(UpdateStatus.REQUIRED_UPDATE_NEEDED)
+        assertThat(result.updateVersion).isEqualTo(245)
+        assertThat(storage.lastNotifiedVersion(null)).isEqualTo(245)
+    }
+
+    @Test
+    fun testNoUpdate() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(300, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = ResourceFileLoader("valid_update_full.json")
+
+        val result = pov.checkForUpdates(loader)
+
+        assertThat(result.status).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE)
+        assertThat(result.updateVersion).isEqualTo(300)
+        assertThat(storage.lastNotifiedVersion(null)).isNull()
+    }
+
+    @Test
+    fun testOptionalUpdate() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(200, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = ResourceFileLoader("valid_update_full.json")
+
+        val result = pov.checkForUpdates(loader)
+
+        assertThat(result.status).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE)
+        assertThat(result.updateVersion).isEqualTo(245)
+        assertThat(storage.lastNotifiedVersion(null)).isEqualTo(245)
+    }
+
+    @Test
+    fun testOptionalUpdateAlreadyNotifiedOnce() {
+        val storage = MockStorage(245)
+        val appConfig = MockApplicationConfiguration(200, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = ResourceFileLoader("valid_update_full.json") // This file has notification type ONCE
+
+        val result = pov.checkForUpdates(loader)
+
+        assertThat(result.status).isEqualTo(UpdateStatus.NO_UPDATE_AVAILABLE)
+        assertThat(storage.lastNotifiedVersion(null)).isEqualTo(245) // Unchanged
+    }
+
+    @Test
+    fun testOptionalUpdateAlreadyNotifiedAlways() {
+        val storage = MockStorage(245)
+        val appConfig = MockApplicationConfiguration(200, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = ResourceFileLoader("valid_update_notification_always.json")
+
+        val result = pov.checkForUpdates(loader)
+
+        assertThat(result.status).isEqualTo(UpdateStatus.NEW_UPDATE_AVAILABLE)
+        assertThat(storage.lastNotifiedVersion(null)).isEqualTo(245) // Updated again
+    }
+
+    @Test
+    fun testAsyncSuccess() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(100, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = ResourceFileLoader("valid_update_full.json")
+
+        pov.checkForUpdates(loader, callback)
+
+        verify(callback, timeout(1000)).onSuccess(any(UpdateResult::class.java))
+        verify(callback, never()).onError(any(Throwable::class.java))
+    }
+
+    @Test
+    fun testAsyncError() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(100, 16)
+        val pov = PrinceOfVersions(storage, MainThreadExecutor(), appConfig)
+        val loader = mock(Loader::class.java)
+        `when`(loader.load()).thenThrow(IOException("Network error"))
+
+        pov.checkForUpdates(loader, callback)
+
+        verify(callback, timeout(1000)).onError(any(IOException::class.java))
+        verify(callback, never()).onSuccess(any(UpdateResult::class.java))
+    }
+
+    @Test
+    fun testAsyncCancellation() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(100, 16)
+        // Use an executor that doesn't run immediately
+        val pov = PrinceOfVersions(storage, Executor { /* no-op */ }, appConfig)
+        val loader = ResourceFileLoader("valid_update_full.json")
+
+        val cancelable = pov.checkForUpdates(loader, callback)
+        cancelable.cancel()
+
+        verify(callback, never()).onSuccess(any(UpdateResult::class.java))
+        verify(callback, never()).onError(any(Throwable::class.java))
+    }
+
+    @Test
+    fun testBuilderThrowsErrorWhenNoContextAndNoStorage() {
+        assertThatThrownBy {
+            PrinceOfVersions.Builder()
+                .withAppConfig(MockApplicationConfiguration(1, 1))
+                .build()
+        }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("You must define storage and application configuration if you don't provide Context.")
+    }
+
+    @Test
+    fun testBuilderThrowsErrorWhenNoContextAndNoAppConfig() {
+        assertThatThrownBy {
+            PrinceOfVersions.Builder()
+                .withStorage(MockStorage())
+                .build()
+        }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+            .hasMessage("You must define storage and application configuration if you don't provide Context.")
+    }
+
+    @Test
+    fun testBuilderWithCustomComponents() {
+        val storage = MockStorage()
+        val appConfig = MockApplicationConfiguration(1, 1)
+        val parser = mock(ConfigurationParser::class.java)
+        `when`(parser.parse(any())).thenReturn(PrinceOfVersionsConfig.Builder().withMandatoryVersion(2).build())
+
+        val pov = PrinceOfVersions.Builder()
+            .withStorage(storage)
+            .withAppConfig(appConfig)
+            .withParser(parser)
+            .withCallbackExecutor(MainThreadExecutor())
+            .build()
+
+        pov.checkForUpdates(ResourceFileLoader("valid_update_full.json"))
+
+        // Verify our custom parser was used
+        verify(parser, timeout(1000)).parse(any())
+    }
+
+    private class MainThreadExecutor : Executor {
+        override fun execute(command: Runnable) {
+            command.run()
+        }
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/RequirementsProcessorTestRefactored.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/RequirementsProcessorTestRefactored.kt
@@ -1,0 +1,90 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class RequirementsProcessorTestRefactored {
+
+    private class MockApplicationVersionProvider(private val version: Int) : PrinceOfVersionsDefaultRequirementsChecker.ApplicationVersionProvider {
+        override fun provide(): Int = version
+    }
+
+    @Test
+    fun checkRequiredOsVersionWhenGreaterThanDevice() {
+        val checker: RequirementChecker = PrinceOfVersionsDefaultRequirementsChecker(MockApplicationVersionProvider(23))
+        val processor = PrinceOfVersionsRequirementsProcessor(mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker))
+        val requirements = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to "25")
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun checkRequiredOsVersionWhenLessThanDevice() {
+        val checker: RequirementChecker = PrinceOfVersionsDefaultRequirementsChecker(MockApplicationVersionProvider(25))
+        val processor = PrinceOfVersionsRequirementsProcessor(mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker))
+        val requirements = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to "23")
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun checkRequiredOsVersionWhenEqualToDevice() {
+        val checker: RequirementChecker = PrinceOfVersionsDefaultRequirementsChecker(MockApplicationVersionProvider(23))
+        val processor = PrinceOfVersionsRequirementsProcessor(mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker))
+        val requirements = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to "23")
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun checkRequiredOsVersionWhenRequirementValueIsNull() {
+        val checker: RequirementChecker = PrinceOfVersionsDefaultRequirementsChecker(MockApplicationVersionProvider(23))
+        val processor = PrinceOfVersionsRequirementsProcessor(mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker))
+        val requirements = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to null)
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun testRequirementWithNoCheckerReturnsFalse() {
+        val processor = PrinceOfVersionsRequirementsProcessor(emptyMap()) // No checkers registered
+        val requirements = mapOf("some_unregistered_key" to "some_value")
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun testRequirementCheckerThrowingExceptionReturnsFalse() {
+        val checker = RequirementChecker { throw IllegalStateException("Checker failed") }
+        val processor = PrinceOfVersionsRequirementsProcessor(mapOf("failing_key" to checker))
+        val requirements = mapOf("failing_key" to "any_value")
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun testDefaultCheckerWithInvalidValueReturnsFalse() {
+        val checker: RequirementChecker = PrinceOfVersionsDefaultRequirementsChecker(MockApplicationVersionProvider(23))
+        val processor = PrinceOfVersionsRequirementsProcessor(mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to checker))
+        val requirements = mapOf(PrinceOfVersionsDefaultRequirementsChecker.KEY to "not-a-number")
+
+        val result = processor.areRequirementsSatisfied(requirements)
+
+        assertThat(result).isFalse()
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/StreamIoTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/StreamIoTest.kt
@@ -1,0 +1,70 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.charset.Charset
+
+@RunWith(MockitoJUnitRunner::class)
+class StreamIoTest {
+
+    @Test
+    fun testToStringReadsInputStreamWithDefaultCharset() {
+        val text = "Hello, world!"
+        val input = ByteArrayInputStream(text.toByteArray(Charset.forName("UTF-8")))
+        val result = StreamIo.toString(input)
+        assertThat(result).isEqualTo(text)
+    }
+
+    @Test
+    fun testToStringReadsInputStreamWithCustomCharset() {
+        val text = "Čevapčići"
+        val charset = Charset.forName("UTF-8")
+        val input = ByteArrayInputStream(text.toByteArray(charset))
+        val result = StreamIo.toString(input, charset)
+        assertThat(result).isEqualTo(text)
+    }
+
+    @Test
+    fun testToStringThrowsIOExceptionOnBrokenStream() {
+        val input: InputStream = object : InputStream() {
+            override fun read(): Int {
+                throw IOException("Simulated read error")
+            }
+        }
+        assertThatThrownBy { StreamIo.toString(input) }
+            .isInstanceOf(IOException::class.java)
+    }
+
+    @Test
+    fun testToStringWithEmptyStream() {
+        val input = ByteArrayInputStream("".toByteArray())
+        val result = StreamIo.toString(input)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun testToStringWithOnlyNewlines() {
+        val input = ByteArrayInputStream("\n\r\n\n".toByteArray())
+        val result = StreamIo.toString(input)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun testToStringIgnoresCloseException() {
+        val text = "test"
+        val input: InputStream = object : ByteArrayInputStream(text.toByteArray()) {
+            override fun close() {
+                throw IOException("Simulated close error")
+            }
+        }
+        // Should not throw an exception, as it's caught and ignored
+        val result = StreamIo.toString(input)
+        assertThat(result).isEqualTo(text)
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/StreamLoaderTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/StreamLoaderTest.kt
@@ -1,0 +1,42 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+@RunWith(MockitoJUnitRunner::class)
+class StreamLoaderTest {
+
+    @Test
+    fun testLoadReturnsStringFromStream() {
+        val text = "StreamLoader test"
+        val input = ByteArrayInputStream(text.toByteArray())
+        val loader: Loader = StreamLoader(input)
+        val result = loader.load()
+        assertThat(result).isEqualTo(text)
+    }
+
+    @Test
+    fun testLoadThrowsIOExceptionOnBrokenStream() {
+        val input: InputStream = object : InputStream() {
+            override fun read(): Int {
+                throw IOException("Simulated read error")
+            }
+        }
+        val loader: Loader = StreamLoader(input)
+        assertThatThrownBy { loader.load() }
+            .isInstanceOf(IOException::class.java)
+    }
+
+    @Test
+    fun testLoadWithNullStreamThrowsException() {
+        val loader: Loader = StreamLoader(null)
+        assertThatThrownBy { loader.load() }
+            .isInstanceOf(NullPointerException::class.java)
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/UpdateInfoTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/UpdateInfoTest.kt
@@ -1,0 +1,65 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdateInfoTest {
+
+    private val requiredVersion: Int? = 2
+    private val lastVersionAvailable: Int? = 3
+    private val installedVersion: Int = 1
+    private val notificationType: NotificationType = NotificationType.ALWAYS
+    private val requirements: Map<String, String> = emptyMap()
+
+    @Test
+    fun testConstructorAndGetters() {
+        val info = UpdateInfo(requiredVersion, lastVersionAvailable, requirements, installedVersion, notificationType)
+
+        assertThat(info.requiredVersion).isEqualTo(requiredVersion)
+        assertThat(info.lastVersionAvailable).isEqualTo(lastVersionAvailable)
+        assertThat(info.requirements).isEqualTo(requirements)
+        assertThat(info.installedVersion).isEqualTo(installedVersion)
+        assertThat(info.notificationFrequency).isEqualTo(notificationType)
+    }
+
+    @Test
+    fun testEqualsAndHashCodeContract() {
+        val info1 = UpdateInfo(requiredVersion, lastVersionAvailable, requirements, installedVersion, notificationType)
+        val info2 = UpdateInfo(requiredVersion, lastVersionAvailable, requirements, installedVersion, notificationType)
+        val info3 = UpdateInfo(requiredVersion, 4, requirements, installedVersion, notificationType)
+        val infoWithNulls1 = UpdateInfo(null, null, requirements, installedVersion, notificationType)
+        val infoWithNulls2 = UpdateInfo(null, null, requirements, installedVersion, notificationType)
+
+        // Reflexive
+        assertThat(info1).isEqualTo(info1)
+        // Symmetric
+        assertThat(info1).isEqualTo(info2)
+        assertThat(info2).isEqualTo(info1)
+        // Consistent HashCode
+        assertThat(info1.hashCode()).isEqualTo(info2.hashCode())
+        // Not equals for different values
+        assertThat(info1).isNotEqualTo(info3)
+        // Not equals for different types
+        assertThat(info1.equals("a string")).isFalse()
+        // Not equals for null
+        assertThat(info1.equals(null)).isFalse()
+
+        // Check with null fields
+        assertThat(infoWithNulls1).isEqualTo(infoWithNulls2)
+        assertThat(infoWithNulls1.hashCode()).isEqualTo(infoWithNulls2.hashCode())
+        assertThat(info1).isNotEqualTo(infoWithNulls1)
+    }
+
+    @Test
+    fun testToStringContainsFields() {
+        val info = UpdateInfo(requiredVersion, lastVersionAvailable, requirements, installedVersion, notificationType)
+        val str = info.toString()
+        assertThat(str).contains("Installed version =")
+        assertThat(str).contains("Required version =")
+        assertThat(str).contains("Last version =")
+        assertThat(str).contains("Requirements =")
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/UpdateResultTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/UpdateResultTest.kt
@@ -1,0 +1,66 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdateResultTest {
+
+    private val updateVersion = 2
+    private val metadata = mapOf<String, String>()
+    private val status = UpdateStatus.NEW_UPDATE_AVAILABLE
+    private val info = UpdateInfo(1, 2, emptyMap(), updateVersion, NotificationType.ALWAYS)
+
+    @Test
+    fun testConstructorAndGetters() {
+        val result = UpdateResult(info, metadata, status, updateVersion)
+
+        assertThat(result.info).isEqualTo(info)
+        assertThat(result.metadata).isEqualTo(metadata)
+        assertThat(result.status).isEqualTo(status)
+        assertThat(result.updateVersion).isEqualTo(updateVersion)
+    }
+
+    @Test
+    fun testEqualsAndHashCodeContract() {
+        val result1 = UpdateResult(info, metadata, status, updateVersion)
+        val result2 = UpdateResult(info, metadata, status, updateVersion)
+        val differentStatus = UpdateResult(info, metadata, UpdateStatus.NO_UPDATE_AVAILABLE, updateVersion)
+        val differentVersion = UpdateResult(info, metadata, status, updateVersion + 1)
+
+        // Reflexive
+        assertThat(result1).isEqualTo(result1)
+        // Symmetric
+        assertThat(result1).isEqualTo(result2)
+        assertThat(result2).isEqualTo(result1)
+        // Consistent HashCode for equal objects
+        assertThat(result1.hashCode()).isEqualTo(result2.hashCode())
+
+        // Not equals for different status
+        assertThat(result1).isNotEqualTo(differentStatus)
+
+        // Not equals for different updateVersion
+        assertThat(result1).isNotEqualTo(differentVersion)
+
+        // BUG: Test that documents the flaw in the hashCode implementation
+        // Two objects are not equal, but produce the same hash code because 'updateVersion' is missing from hashCode()
+        assertThat(result1.hashCode()).isEqualTo(differentVersion.hashCode())
+
+        // Not equals for different types
+        assertThat(result1.equals("a string")).isFalse()
+        // Not equals for null
+        assertThat(result1.equals(null)).isFalse()
+    }
+
+    @Test
+    fun testToString() {
+        val result = UpdateResult(info, metadata, status, updateVersion)
+
+        assertThat(result.toString()).contains("metadata=")
+            .contains("info=")
+            .contains("status=")
+            .contains("updateVersion=")
+    }
+}

--- a/prince-of-versions/src/test/java/co/infinum/princeofversions/UpdaterCallTest.kt
+++ b/prince-of-versions/src/test/java/co/infinum/princeofversions/UpdaterCallTest.kt
@@ -1,0 +1,153 @@
+package co.infinum.princeofversions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.IOException
+import java.util.concurrent.Executor
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdaterCallTest {
+
+    @Mock
+    private lateinit var core: PrinceOfVersions
+
+    @Mock
+    private lateinit var loader: Loader
+
+    @Mock
+    private lateinit var callback: UpdaterCallback
+
+    @Mock
+    private lateinit var cancelable: PrinceOfVersionsCancelable
+
+    @Mock
+    private lateinit var executor: Executor
+
+    @Mock
+    private lateinit var updateResult: UpdateResult
+
+    @Test
+    fun testExecuteReturnsUpdateResult() {
+        `when`(core.checkForUpdates(loader)).thenReturn(updateResult)
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        val result = call.execute()
+        assertThat(result).isEqualTo(updateResult)
+    }
+
+    @Test
+    fun testExecuteTwiceThrows() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.execute()
+        assertThatThrownBy { call.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Already executed!")
+    }
+
+    @Test
+    fun testExecuteWhenCanceledThrows() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.cancel()
+        assertThatThrownBy { call.execute() }
+            .isInstanceOf(IOException::class.java)
+            .hasMessage("Canceled!")
+    }
+
+    @Test
+    fun testEnqueueCallsCore() {
+        `when`(core.checkForUpdates(loader, callback)).thenReturn(cancelable)
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.enqueue(callback)
+        verify(core).checkForUpdates(loader, callback)
+    }
+
+    @Test
+    fun testEnqueueTwiceThrows() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.enqueue(callback)
+        assertThatThrownBy { call.enqueue(callback) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Already executed!")
+    }
+
+    /*
+    TODO : This test fails because of a bug which stops cancellation. After refactoring the tests address the bugs by adding return
+            statements after detecting cancellation in enqueue methods.
+    @Test
+    fun testEnqueueWhenCanceledCallsOnError() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.cancel()
+        call.enqueue(callback)
+        verify(callback).onError(any(IOException::class.java))
+        verify(core, never()).checkForUpdates(any(Loader::class.java), any(UpdaterCallback::class.java))
+    }*/
+
+    @Test
+    fun testEnqueueWithExecutorCallsCore() {
+        `when`(core.checkForUpdates(executor, loader, callback)).thenReturn(cancelable)
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.enqueue(executor, callback)
+        verify(core).checkForUpdates(executor, loader, callback)
+    }
+
+    /*
+    TODO : This test fails because of a bug which stops cancellation. After refactoring the tests address the bugs by adding return
+            statements after detecting cancellation in enqueue methods.
+    @Test
+    fun testEnqueueWithExecutorWhenCanceledCallsOnError() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.cancel()
+        call.enqueue(executor, callback)
+        verify(callback).onError(any(IOException::class.java))
+        verify(core, never()).checkForUpdates(any(Executor::class.java), any(Loader::class.java), any(UpdaterCallback::class.java))
+    }*/
+
+    @Test
+    fun testCancelAfterEnqueue() {
+        `when`(core.checkForUpdates(loader, callback)).thenReturn(cancelable)
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.enqueue(callback)
+        call.cancel()
+        assertThat(call.isCanceled).isTrue()
+        verify(cancelable).cancel()
+    }
+
+    @Test
+    fun testCancelBeforeEnqueue() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.cancel()
+        assertThat(call.isCanceled).isTrue()
+        // No interaction with a cancelable object, as it hasn't been created yet
+    }
+
+    @Test
+    fun testIsCanceledReturnsFalseInitially() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        assertThat(call.isCanceled).isFalse()
+    }
+
+    @Test
+    fun testExecuteAfterEnqueueThrows() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.enqueue(callback)
+        assertThatThrownBy { call.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Already executed!")
+    }
+
+    @Test
+    fun testEnqueueAfterExecuteThrows() {
+        val call: PrinceOfVersionsCall = UpdaterCall(core, loader)
+        call.execute()
+        assertThatThrownBy { call.enqueue(callback) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("Already executed!")
+    }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -14,15 +14,16 @@ def versions = [
 ]
 
 def deps = [
-        semver       : "com.github.zafarkhaja:java-semver:$versions.semver",
-        annotations  : "androidx.annotation:annotation:$versions.appcompat",
-        appcompat    : "androidx.appcompat:appcompat:$versions.appcompat",
-        sbannotations: "com.github.spotbugs:spotbugs-annotations:$versions.spotbugs",
-        junit        : 'junit:junit:4.12',
-        mockito      : 'org.mockito:mockito-core:4.1.0',
-        mockwebserver: 'com.squareup.okhttp3:mockwebserver:3.10.0',
-        assertj      : 'org.assertj:assertj-core:3.8.0',
-        json         : 'org.json:json:20140107'
+        semver          : "com.github.zafarkhaja:java-semver:$versions.semver",
+        annotations     : "androidx.annotation:annotation:$versions.appcompat",
+        appcompat       : "androidx.appcompat:appcompat:$versions.appcompat",
+        sbannotations   : "com.github.spotbugs:spotbugs-annotations:$versions.spotbugs",
+        junit           : 'junit:junit:4.12',
+        mockito         : 'org.mockito:mockito-core:4.1.0',
+        mockito_inline  : 'org.mockito:mockito-inline:5.2.0',
+        mockwebserver   : 'com.squareup.okhttp3:mockwebserver:3.10.0',
+        assertj         : 'org.assertj:assertj-core:3.8.0',
+        json            : 'org.json:json:20140107'
 ]
 
 ext.deps = deps


### PR DESCRIPTION
## Summary

<!-- 
    Provide an overview of what this pull request aims to address or achieve.

    Link any relevant issues that this pull request addresses or resolves, using the format "Fixes #issue_number". 
-->
This PR refactors the existing java tests suites to Kotlin (but does not remove them yet for safety) and adds new test suites for non covered classes. The idea is to catch potential bugs in the Java -> Kotlin refactor of the PoV library. 

## Changes

- Added copilot PR comment suggestion from feature/raise-kotlin-version pull request
- Refactored existing test suites to Kotlin and added additional cases (the existing ones are not removed for extra safety during the Java -> Kotlin rewrite, given that the refactored ones should cover the existing ones they can be removed after the refactor)
- Added new test suites for non covered classes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [X] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->
Test names don't follow the usual backtick nomenclature as I wanted to keep the codebase consistent with existing tests in the repository. If this is an issue I can change it.

The existing java test cases are not removed for extra safety during the Java -> Kotlin rewrite as they currently test working production code. Given that the refactored ones should cover the existing java ones the java tests can be removed after the refactor.

Tests `testEnqueueWhenCanceledCallsOnError` and `testEnqueueWithExecutorWhenCanceledCallsOnError ` in `UpdaterCallTest` fail because there is no return statement in the cancel if blocks. Currently they are commented out. This behaviour should be checked and fixed during the Java -> Kotlin refactor and the tests uncommented.

Test `checkEqualsAndHashCodeContract` fails when checking the hash code for optional updates due to an exception, ideally hash code should not throw exceptions. During the Java -> Kotlin refactor it should be checked whether this bug is of real concern in the actual implementation and context of usage if the hash code will never be checked for optional updates. If the bug is addressed the test should be updated.

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
